### PR TITLE
drop "byte" variable

### DIFF
--- a/format.js
+++ b/format.js
@@ -26,14 +26,13 @@
 module.exports = function (random, alphabet, size) {
   var step = Math.ceil(310 / alphabet.length * size)
 
-  var bytes, byte
+  var bytes
   var id = ''
   while (true) {
     bytes = random(step)
     for (var i = 0; i < bytes.length; i++) {
-      byte = bytes[i]
-      if (byte < alphabet.length) {
-        id += alphabet[byte]
+      if (bytes[i] < alphabet.length) {
+        id += alphabet[bytes[i]]
         if (id.length === size) return id
       }
     }


### PR DESCRIPTION
somehow speed is increased a bit (possibly, on omitting pointer allocation) and -5 bytes of output file size is gained. 
On benchmark branch commit (https://github.com/ai/nanoid/pull/11) I've got (on macbook pro 2015 i7)
```
vrodionov ~/W/nanoid> node benchmark #without this commit
nanoid#generate x 72,079 ops/sec ±1.65% (85 runs sampled)
vrodionov ~/W/nanoid> node benchmark #with this commit
nanoid#generate x 77,860 ops/sec ±0.90% (86 runs sampled)
```