### PR TITLE
Calculate mask directly from alphabet length

### DIFF
--- a/format.js
+++ b/format.js
@@ -1,5 +1,3 @@
-var masks = [15, 31, 63, 127, 255]
-
 /**
  * Secure random string generator with custom alphabet.
  *
@@ -26,9 +24,7 @@ var masks = [15, 31, 63, 127, 255]
  * @name format
  */
 module.exports = function (random, alphabet, size) {
-  var mask = masks.find(function (i) {
-    return i >= alphabet.length - 1
-  })
+  var mask = (2 << Math.log(alphabet.length - 1) / Math.LN2) - 1
   var step = Math.ceil(1.6 * mask * size / alphabet.length)
 
   var id = ''

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     },
     {
       "path": "generate.js",
-      "limit": "196 B"
+      "limit": "184 B"
     }
   ],
   "lint-staged": {


### PR DESCRIPTION
Calculate `mask` directly from `alphabet.length` using log base 2 and some bitshifts

## "Sanity check"
| dictionary length | mask value |
|--|--|
| 0 | 1 |
| 1 | 1 |
| 2 | 1 |
| 3 | 3 |
| 4 | 3 |
| 5 | 7 |
| 6 | 7 |
| 7 | 7 |
| 8 | 7 |
| 9 | 15 |
| _..._ | 15 |
| 16 | 15 |
| 17 | 31 |
| _..._ | 31 |
| 32 | 31 |
| 33 | 63 |
| _..._ | 63 |
| 64 | 63 |
| 65 | 127 |
| _..._ | 127 |
| 128 | 127 |
| 129 | 255 |
| _..._ | 255 |
| 256 | 255 |
