### PR TITLE
Separate, size optimized implementation of index.js for browsers

### DIFF
--- a/index-browser.js
+++ b/index-browser.js
@@ -1,0 +1,33 @@
+/* eslint-env browser, es5 */
+/**
+ * Generate secure URL-friendly unique ID.
+ *
+ * By default, ID will have 21 symbols to have a collision probability similar
+ * to UUID v4.
+ *
+ * @param {number} [size=21] The number of symbols in ID.
+ *
+ * @return {string} Random string.
+ *
+ * @example
+ * var nanoid = require('nanoid')
+ * model.id = nanoid() //=> "Uakgb_J5m9g~0JDMbcJqL"
+ *
+ * @name nanoid
+ */
+module.exports = function (size) {
+  size = size || 21
+  return (
+    btoa(
+      String.fromCharCode.apply(
+        0,
+        (window.crypto || window.msCrypto).getRandomValues(
+          new Uint8Array(-~size * 0.75)
+        )
+      )
+    )
+      .replace(/\+/g, '_')
+      .replace(/\//g, '~')
+      .slice(0, size)
+  )
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "license": "MIT",
   "repository": "ai/nanoid",
   "browser": {
-    "./random.js": "./random-browser.js"
+    "./random.js": "./random-browser.js",
+    "./index.js": "./index-browser.js"
   },
   "devDependencies": {
     "benchmark": "^2.1.4",
@@ -63,7 +64,7 @@
   "size-limit": [
     {
       "path": "index.js",
-      "limit": "179 B"
+      "limit": "121 B"
     },
     {
       "path": "generate.js",


### PR DESCRIPTION
It turned out, `btoa`/`atob` are actually [parts of HTML5 spec](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/btoa) now, and it's widely supported, so we could use it as a "shortcut" version for index.js in browsers.

The main idea is that the default dictionary shares 62 out of 64 chars with a base64 dictionary. And base64 preserves the uniform random distribution.