### PR TITLE
176 b: Reverse loop, reuse var

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,8 +22,12 @@ module.exports = function (size) {
   size = size || 21
   var id = ''
   var bytes = random(size)
-  for (var i = 0; i < size; i++) {
-    id += url[bytes[i] & 63]
+
+  // `i-- > 0` becomes `i-- >0` when minified
+  // `0 < i--` becomes `0<i--`
+  // eslint-disable-next-line yoda
+  while (0 < size--) {
+    id += url[bytes[size] & 63]
   }
   return id
 }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "size-limit": [
     {
       "path": "index.js",
-      "limit": "179 B"
+      "limit": "176 B"
     },
     {
       "path": "generate.js",


### PR DESCRIPTION
There's no difference, in which direction we're traversing the array of random values: they're random.

The loop was reversed, so the size can be reused as a loop counter.

I had to temporary disable a `yoda` eslint rule for one line. The reason is, Uglify cannot minify `i-- > 0` to `i-->0` because `-->` can be parsed as [a single token](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-html-like-comments).