### PR TITLE
Changed example of the nanoid output

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A tiny, secure, URL-friendly, unique string ID generator for JavaScript.
 
 ```js
 var nanoid = require('nanoid')
-model.id = nanoid() //=> "Uakgb_J5m9g~0JDMbcJqLJ"
+model.id = nanoid() //=> "V1StGXR8_Z5jdHi6B~myT"
 ```
 
 **Safe.** It uses cryptographically strong random APIs


### PR DESCRIPTION
In the example of the nanoid output was a string with 22 characters length, changed it to the correct string with length 21 characters