### PR TITLE
fix: use self when referencing the global scope

### DIFF
--- a/random-browser.js
+++ b/random-browser.js
@@ -1,4 +1,4 @@
-var crypto = window.crypto || window.msCrypto
+var crypto = self.crypto || self.msCrypto
 
 module.exports = function (bytes) {
   return crypto.getRandomValues(new Uint8Array(bytes))


### PR DESCRIPTION
Currently you are not able to use `nanoid` inside of a [Worker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API). This is due to `window` not being defined in [`WorkerGlobalScope`](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope). This PR fixes the compatibility problem by using [`self`](https://developer.mozilla.org/en-US/docs/Web/API/Window/self) instead of `window`.