### PR TITLE
Add cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,27 @@ var url = require('nanoid/url')
 format(random, url, 10) //=> "93ce_Ltuub"
 ```
 
+### CLI
+
+You can use `nanoid` from the command line:
+
+```sh
+$ nanoid
+Znb2I~ePaxz5flnzdFkDV
+```
+
+To use a different alphabet, supply the `--alphabet` or `-a` option:
+
+```sh
+$ nanoid --alphabet "_~0123456789abcdefghijklmnopqrstuvwxyz"
+```
+
+To generate a different size id, supply the `--size` or `-s` option:
+
+```sh
+$ nanoid --size 32
+```
+
 
 ## Other Programming Languages
 

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+
+var minimist = require('minimist');
+var generate = require('./generate');
+var alphabet = require('./url');
+
+var options = minimist(process.argv.slice(2), {
+  string: ['alphabet'],
+  alias: {
+    alphabet: 'a',
+    size: 's'
+  },
+  default: {
+    alphabet: alphabet,
+    size: 21
+  }
+});
+
+process.stdout.write(generate(options.alphabet, options.size));

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "browser": {
     "./random.js": "./random-browser.js"
   },
+  "bin": "./cli.js",
   "devDependencies": {
     "benchmark": "^2.1.4",
     "chalk": "^2.3.1",
@@ -81,5 +82,8 @@
   },
   "pre-commit": [
     "lint-staged"
-  ]
+  ],
+  "dependencies": {
+    "minimist": "1.2.0"
+  }
 }


### PR DESCRIPTION
A couple times I've wanted to be able to generate a nanoid from the command line. This adds a cli to the package. If you're opposed to adding `minimist` as a dependency, I'd be willing to update the PR to parse the arguments manually.