### PR TITLE
Make the chars order GZIP-friendly

### DIFF
--- a/.size-limit
+++ b/.size-limit
@@ -1,7 +1,7 @@
 [
   {
     "path": "index.js",
-    "limit": "162 B"
+    "limit": "154 B"
   },
   {
     "path": "generate.js",

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var random = require('./random')
 
-var url = '_~0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+var url = '_~getRandomVcryp0123456789bfhijklqsuvwxzABCDEFGHIJKLMNOPQSTUWXYZ'
 
 /**
  * Generate secure URL-friendly unique ID.


### PR DESCRIPTION
The string contains all the same characters: Alphanumeric and `~_`, but their order has changed:

For the code itself the order is not significant, but it's significant when serving a GZIPped code to the client. 

There's a very high chance words `crypto` and `getRandomValues` will be bundled somewhere near this string. And GZIP now has the opportunity to just copy the whole `getRandomV` and `cryp` string runs via backreferences (which of these "costs" only a few bits) instead of plain Huffman encoding.

Overall, this technique saves 8 .min.gz bytes - 5% of the entire entry size