### PR TITLE
chore: remove Node.js 9 from Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 cache: yarn
 node_js:
   - node
-  - "9"
   - "8"
   - "6"
 git:


### PR DESCRIPTION
Node.js 6, 8 and 10 are LTS and stable releases. The releases between them are short living branches which are not supported when an LTS release is done.

Node.js 9 reached its EOL on 30th of June
https://github.com/nodejs/Release