### PR TITLE
Use `|` operator instead of Math.floor()

### DIFF
--- a/non-secure.js
+++ b/non-secure.js
@@ -22,7 +22,7 @@ module.exports = function (size) {
   size = size || 21
   var id = ''
   while (0 < size--) {
-    id += url[Math.floor(Math.random() * 63)]
+    id += url[Math.random() * 63 | 0]
   }
   return id
 }


### PR DESCRIPTION
Use `|` operator instead of `Math.floor()`.

Now, my name *might* be saved in history ;-)