### PR TITLE
Fix bug in non-secure.js

### DIFF
--- a/non-secure.js
+++ b/non-secure.js
@@ -22,7 +22,7 @@ module.exports = function (size) {
   size = size || 21
   var id = ''
   while (0 < size--) {
-    id += url[Math.random() * 63 | 0]
+    id += url[Math.random() * 64 | 0]
   }
   return id
 }


### PR DESCRIPTION
The `Math.random` function returns a number in the range 0–1 (inclusive of 0, but not 1), so `Math.random() * 63 | 0` will never return 63.