### PR TITLE
perf: preallocate buffers in nodejs.

### DIFF
--- a/async.js
+++ b/async.js
@@ -24,8 +24,9 @@ var url = require('./url')
  */
 module.exports = function (size, callback) {
   size = size || 21
+  var buffer = Buffer.allocUnsafe(size)
   if (callback) {
-    crypto.randomBytes(size, function (err, bytes) {
+    crypto.randomFill(buffer, 0, size, function (err, bytes) {
       if (err) {
         callback(err)
       } else {
@@ -38,7 +39,7 @@ module.exports = function (size, callback) {
     })
   } else {
     return new Promise(function (resolve, reject) {
-      crypto.randomBytes(size, function (err, bytes) {
+      crypto.randomFill(buffer, 0, size, function (err, bytes) {
         if (err) {
           reject(err)
         } else {

--- a/random.js
+++ b/random.js
@@ -1,1 +1,8 @@
-module.exports = require('crypto').randomBytes
+var crypto = require('crypto')
+
+module.exports = function (bytes) {
+  var buffer = Buffer.allocUnsafe(bytes)
+  crypto.randomFillSync(buffer)
+
+  return buffer
+}

--- a/test/async.test.js
+++ b/test/async.test.js
@@ -91,7 +91,7 @@ it('has callback API', function (done) {
 
 it('sends error to callback API', function (done) {
   var error = new Error('test')
-  crypto.randomBytes = function (size, callback) {
+  crypto.randomFill = function (buf, offset, size, callback) {
     callback(error)
   }
   async(10, function (err, id) {


### PR DESCRIPTION
Improve perfomance for nodejs version. My results:

#### before
```
nanoid                331,738 ops/sec
nanoid/generate       327,488 ops/sec
uid.sync              327,499 ops/sec
uuid/v4               321,873 ops/sec
shortid                31,894 ops/sec

Async:
uid                    61,713 ops/sec
nanoid/async           60,515 ops/sec

Non-secure:
rndm                2,310,600 ops/sec
nanoid/non-secure   2,441,124 ops/sec
```

#### after
```
nanoid                374,446 ops/sec
nanoid/generate       367,777 ops/sec
uid.sync              326,813 ops/sec
uuid/v4               322,756 ops/sec
shortid                31,409 ops/sec

Async:
uid                    62,463 ops/sec
nanoid/async           66,546 ops/sec

Non-secure:
rndm                2,323,620 ops/sec
nanoid/non-secure   2,463,917 ops/sec
```