### PR TITLE
Restore support for Node.js<v6.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ node_js:
   - node
   - "8"
   - "6"
+  - "6.12.0"
 git:
   depth: 5

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,5 @@ node_js:
   - node
   - "8"
   - "6"
-  - "6.12.0"
 git:
   depth: 5

--- a/async.js
+++ b/async.js
@@ -24,24 +24,28 @@ var random = require('./random')
 module.exports = function (size, callback) {
   size = size || 21
 
-  var randomPromise = random.async(size)
-    .then(function (bytes) {
-      var id = ''
-      while (0 < size--) {
-        id += url[bytes[size] & 63]
-      }
-      return id
-    })
-
   if (!callback) {
-    return randomPromise
+    return new Promise(function (resolve, reject) {
+      module.exports(size, function (error, id) {
+        if (error) {
+          reject(error)
+        } else {
+          resolve(id)
+        }
+      })
+    })
   }
 
-  randomPromise
-    .then(function (buffer) {
-      callback(null, buffer)
-    })
-    .catch(function (error) {
-      callback(error)
-    })
+  random.async(size, function (error, bytes) {
+    if (error) {
+      return callback(error)
+    }
+
+    var id = ''
+    while (0 < size--) {
+      id += url[bytes[size] & 63]
+    }
+
+    callback(null, id)
+  })
 }

--- a/random.js
+++ b/random.js
@@ -1,23 +1,17 @@
 var crypto = require('crypto')
 
-module.exports = function (bytes) {
-  if (!crypto.randomFillSync) {
-    return crypto.randomBytes(bytes)
+if (crypto.randomFillSync) {
+  module.exports = function (bytes) {
+    return crypto.randomFillSync(Buffer.allocUnsafe(bytes))
   }
-
-  return crypto.randomFillSync(Buffer.allocUnsafe(bytes))
+} else {
+  module.exports = crypto.randomBytes
 }
 
-module.exports.async = function (bytes) {
-  return new Promise(function (resolve, reject) {
-    function callback (error, buffer) {
-      error ? reject(error) : resolve(buffer)
-    }
-
-    if (crypto.randomFill) {
-      crypto.randomFill(Buffer.allocUnsafe(bytes), callback)
-    } else {
-      crypto.randomBytes(bytes, callback)
-    }
-  })
+if (crypto.randomFill) {
+  module.exports.async = function (bytes, callback) {
+    return crypto.randomFill(Buffer.allocUnsafe(bytes), callback)
+  }
+} else {
+  module.exports.async = crypto.randomBytes
 }

--- a/random.js
+++ b/random.js
@@ -1,8 +1,23 @@
 var crypto = require('crypto')
 
 module.exports = function (bytes) {
-  var buffer = Buffer.allocUnsafe(bytes)
-  crypto.randomFillSync(buffer)
+  if (!crypto.randomFillSync) {
+    return crypto.randomBytes(bytes)
+  }
 
-  return buffer
+  return crypto.randomFillSync(Buffer.allocUnsafe(bytes))
+}
+
+module.exports.async = function (bytes) {
+  return new Promise(function (resolve, reject) {
+    function callback (error, buffer) {
+      error ? reject(error) : resolve(buffer)
+    }
+
+    if (crypto.randomFill) {
+      crypto.randomFill(Buffer.allocUnsafe(bytes), callback)
+    } else {
+      crypto.randomBytes(bytes, callback)
+    }
+  })
 }

--- a/test/async.test.js
+++ b/test/async.test.js
@@ -74,7 +74,7 @@ it('has flat distribution', function () {
 
 it('rejects Promise on error', function () {
   var error = new Error('test')
-  crypto.randomFill = function (buffer, a, b, callback) {
+  crypto.randomFill = function (buffer, callback) {
     callback(error)
   }
   return async().catch(function (e) {
@@ -91,7 +91,7 @@ it('has callback API', function (done) {
 
 it('sends error to callback API', function (done) {
   var error = new Error('test')
-  crypto.randomFill = function (buf, offset, size, callback) {
+  crypto.randomFill = function (buf, callback) {
     callback(error)
   }
   async(10, function (err, id) {

--- a/test/async.test.js
+++ b/test/async.test.js
@@ -14,6 +14,9 @@ function times (size, callback) {
 var originFill = crypto.randomFill
 afterEach(function () {
   crypto.randomFill = originFill
+
+  jest.resetModules()
+  async = require('../async') // eslint-disable-line global-require
 })
 
 it('generates URL-friendly IDs', function () {
@@ -77,6 +80,10 @@ it('rejects Promise on error', function () {
   crypto.randomFill = function (buffer, callback) {
     callback(error)
   }
+
+  jest.resetModules()
+  async = require('../async') // eslint-disable-line global-require
+
   return async().catch(function (e) {
     expect(e).toBe(error)
   })
@@ -94,6 +101,10 @@ it('sends error to callback API', function (done) {
   crypto.randomFill = function (buf, callback) {
     callback(error)
   }
+
+  jest.resetModules()
+  async = require('../async') // eslint-disable-line global-require
+
   async(10, function (err, id) {
     expect(err).toBe(error)
     expect(id).toBeUndefined()

--- a/test/random.test.js
+++ b/test/random.test.js
@@ -1,6 +1,18 @@
+var crypto = require('crypto')
+
 var random = require('../random')
 
-it('generates random buffers', function () {
+var originFill = crypto.randomFill
+var originFillSync = crypto.randomFillSync
+
+afterEach(function () {
+  crypto.randomFill = originFill
+  crypto.randomFillSync = originFillSync
+})
+
+it('generates random buffers (slow & sync)', function () {
+  delete crypto.randomFillSync
+
   var numbers = { }
   var bytes = random(10000)
   expect(bytes).toHaveLength(10000)
@@ -11,4 +23,93 @@ it('generates random buffers', function () {
     expect(bytes[i]).toBeLessThanOrEqual(255)
     expect(bytes[i]).toBeGreaterThanOrEqual(0)
   }
+})
+
+it('generates random buffers (slow & async)', function () {
+  delete crypto.randomFill
+
+  var numbers = { }
+
+  return random.async(10000)
+    .then(function (bytes) {
+      expect(bytes).toHaveLength(10000)
+      for (var i = 0; i < bytes.length; i++) {
+        if (!numbers[bytes[i]]) numbers[bytes[i]] = 0
+        numbers[bytes[i]] += 1
+        expect(typeof bytes[i]).toEqual('number')
+        expect(bytes[i]).toBeLessThanOrEqual(255)
+        expect(bytes[i]).toBeGreaterThanOrEqual(0)
+      }
+    })
+})
+
+it('generates random buffers (fast & sync)', function () {
+  crypto.randomFill = function (buffer) {
+    var data = crypto.randomBytes(buffer.length)
+    data.copy(buffer)
+    return buffer
+  }
+
+  var numbers = { }
+  var bytes = random(10000)
+  expect(bytes).toHaveLength(10000)
+  for (var i = 0; i < bytes.length; i++) {
+    if (!numbers[bytes[i]]) numbers[bytes[i]] = 0
+    numbers[bytes[i]] += 1
+    expect(typeof bytes[i]).toEqual('number')
+    expect(bytes[i]).toBeLessThanOrEqual(255)
+    expect(bytes[i]).toBeGreaterThanOrEqual(0)
+  }
+})
+
+it('generates random buffers (fast & async)', function () {
+  crypto.randomFill = function (buffer, callback) {
+    return crypto.randomBytes(buffer.length, function (err, data) {
+      if (err) {
+        return callback(err)
+      }
+
+      data.copy(buffer)
+      callback(null, buffer)
+    })
+  }
+
+  var numbers = { }
+
+  return random.async(10000)
+    .then(function (bytes) {
+      expect(bytes).toHaveLength(10000)
+      for (var i = 0; i < bytes.length; i++) {
+        if (!numbers[bytes[i]]) numbers[bytes[i]] = 0
+        numbers[bytes[i]] += 1
+        expect(typeof bytes[i]).toEqual('number')
+        expect(bytes[i]).toBeLessThanOrEqual(255)
+        expect(bytes[i]).toBeGreaterThanOrEqual(0)
+      }
+    })
+})
+
+it('passes error from crypto module (sync)', function () {
+  var error = new Error('test')
+  crypto.randomFillSync = function () {
+    throw error
+  }
+
+  try {
+    random(10000)
+  } catch (e) {
+    expect(e).toBe(error)
+  }
+})
+
+it('passes error from crypto module (async)', function () {
+  var error = new Error('test')
+  crypto.randomFill = function (buffer, callback) {
+    callback(error)
+  }
+
+  return random.async(10000)
+    .catch(function (e) {
+      expect(e).toBe(error)
+    })
 })

--- a/test/random.test.js
+++ b/test/random.test.js
@@ -1,5 +1,4 @@
 var crypto = require('crypto')
-
 var random = require('../random')
 
 var originFill = crypto.randomFill
@@ -8,10 +7,16 @@ var originFillSync = crypto.randomFillSync
 afterEach(function () {
   crypto.randomFill = originFill
   crypto.randomFillSync = originFillSync
+
+  jest.resetModules()
+  random = require('../random') // eslint-disable-line global-require
 })
 
 it('generates random buffers (slow & sync)', function () {
   delete crypto.randomFillSync
+
+  jest.resetModules()
+  random = require('../random') // eslint-disable-line global-require
 
   var numbers = { }
   var bytes = random(10000)
@@ -25,22 +30,25 @@ it('generates random buffers (slow & sync)', function () {
   }
 })
 
-it('generates random buffers (slow & async)', function () {
+it('generates random buffers (slow & async)', function (done) {
   delete crypto.randomFill
+
+  jest.resetModules()
+  random = require('../random') // eslint-disable-line global-require
 
   var numbers = { }
 
-  return random.async(10000)
-    .then(function (bytes) {
-      expect(bytes).toHaveLength(10000)
-      for (var i = 0; i < bytes.length; i++) {
-        if (!numbers[bytes[i]]) numbers[bytes[i]] = 0
-        numbers[bytes[i]] += 1
-        expect(typeof bytes[i]).toEqual('number')
-        expect(bytes[i]).toBeLessThanOrEqual(255)
-        expect(bytes[i]).toBeGreaterThanOrEqual(0)
-      }
-    })
+  random.async(10000, function (error, bytes) {
+    expect(bytes).toHaveLength(10000)
+    for (var i = 0; i < bytes.length; i++) {
+      if (!numbers[bytes[i]]) numbers[bytes[i]] = 0
+      numbers[bytes[i]] += 1
+      expect(typeof bytes[i]).toEqual('number')
+      expect(bytes[i]).toBeLessThanOrEqual(255)
+      expect(bytes[i]).toBeGreaterThanOrEqual(0)
+      done()
+    }
+  })
 })
 
 it('generates random buffers (fast & sync)', function () {
@@ -50,6 +58,9 @@ it('generates random buffers (fast & sync)', function () {
     return buffer
   }
 
+  jest.resetModules()
+  random = require('../random') // eslint-disable-line global-require
+
   var numbers = { }
   var bytes = random(10000)
   expect(bytes).toHaveLength(10000)
@@ -62,7 +73,7 @@ it('generates random buffers (fast & sync)', function () {
   }
 })
 
-it('generates random buffers (fast & async)', function () {
+it('generates random buffers (fast & async)', function (done) {
   crypto.randomFill = function (buffer, callback) {
     return crypto.randomBytes(buffer.length, function (err, data) {
       if (err) {
@@ -74,19 +85,22 @@ it('generates random buffers (fast & async)', function () {
     })
   }
 
+  jest.resetModules()
+  random = require('../random') // eslint-disable-line global-require
+
   var numbers = { }
 
-  return random.async(10000)
-    .then(function (bytes) {
-      expect(bytes).toHaveLength(10000)
-      for (var i = 0; i < bytes.length; i++) {
-        if (!numbers[bytes[i]]) numbers[bytes[i]] = 0
-        numbers[bytes[i]] += 1
-        expect(typeof bytes[i]).toEqual('number')
-        expect(bytes[i]).toBeLessThanOrEqual(255)
-        expect(bytes[i]).toBeGreaterThanOrEqual(0)
-      }
-    })
+  random.async(10000, function (error, bytes) {
+    expect(bytes).toHaveLength(10000)
+    for (var i = 0; i < bytes.length; i++) {
+      if (!numbers[bytes[i]]) numbers[bytes[i]] = 0
+      numbers[bytes[i]] += 1
+      expect(typeof bytes[i]).toEqual('number')
+      expect(bytes[i]).toBeLessThanOrEqual(255)
+      expect(bytes[i]).toBeGreaterThanOrEqual(0)
+      done()
+    }
+  })
 })
 
 it('passes error from crypto module (sync)', function () {
@@ -95,6 +109,9 @@ it('passes error from crypto module (sync)', function () {
     throw error
   }
 
+  jest.resetModules()
+  random = require('../random') // eslint-disable-line global-require
+
   try {
     random(10000)
   } catch (e) {
@@ -102,14 +119,17 @@ it('passes error from crypto module (sync)', function () {
   }
 })
 
-it('passes error from crypto module (async)', function () {
+it('passes error from crypto module (async)', function (done) {
   var error = new Error('test')
   crypto.randomFill = function (buffer, callback) {
     callback(error)
   }
 
-  return random.async(10000)
-    .catch(function (e) {
-      expect(e).toBe(error)
-    })
+  jest.resetModules()
+  random = require('../random') // eslint-disable-line global-require
+
+  return random.async(10000, function (e) {
+    expect(e).toBe(error)
+    done()
+  })
 })


### PR DESCRIPTION
Unfortunately I can't add an older Node config to the TravisCI env, because `eslint` requires `node>=6.14.0` (see the tests for the first commit)