### PR TITLE
Reduce url symbols size for 3 bytes

### DIFF
--- a/url.js
+++ b/url.js
@@ -1,6 +1,9 @@
 /**
  * URL safe symbols.
  *
+ * This alphabet uses a-zA-Z0-9_~ symbols.
+ * (Symbols order was changed for better gzip compression.)
+ *
  * @name url
  * @type {string}
  *

--- a/url.js
+++ b/url.js
@@ -9,6 +9,6 @@
  * generate(url, 10) //=> "Uakgb_J5m9"
  */
 module.exports =
-  '_~0123456789' +
-  'abcdefghijklmnopqrstuvwxyz' +
+  'functio_~0123456789' +
+  'abdeghjklmpqrsvwxyz' +
   'ABCDEFGHIJKLMNOPQRSTUVWXYZ'


### PR DESCRIPTION
Some symbols movement for improving gzip size from 73 bytes to 70 (checked with size-limit)