### PR TITLE
Remove extra `typeof`

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ module.exports = function (size, attempt) {
   try {
     bytes = random(size)
   } catch (e) {
-    if (typeof attempt === 'undefined') attempt = 3
+    if (attempt === undefined) attempt = 3
     attempt -= 1
     if (attempt === 0) {
       throw e


### PR DESCRIPTION
When `typeof` is used with unresolved reference, it swallows `ReferenceError` and returns `"undefined"`. `attempt` binding is defined here, so it is safe to compare to `undefined` directly.