### PR TITLE
test: add benchmark for secure-random-string

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "parcel-bundler": "^1.12.1",
     "rimraf": "^2.6.3",
     "rndm": "^1.2.0",
+    "secure-random-string": "^1.1.0",
     "shortid": "^2.2.14",
     "size-limit": "^0.21.1",
     "uid-safe": "^2.1.5",

--- a/test/benchmark
+++ b/test/benchmark
@@ -4,6 +4,7 @@ var shortid = require('shortid')
 var uuid4 = require('uuid/v4')
 var chalk = require('chalk')
 var rndm = require('rndm')
+var srs = require('secure-random-string')
 var uid = require('uid-safe')
 
 var asyncGenerate = require('../async/generate')
@@ -36,6 +37,9 @@ suite
   .add('shortid', function () {
     shortid()
   })
+  .add('secure-random-string', function () {
+    srs()
+  })
   .add('nanoid/async', {
     defer: true,
     fn: function (defer) {
@@ -50,6 +54,12 @@ suite
       asyncGenerate('1234567890abcdef-', 10).then(function () {
         defer.resolve()
       })
+    }
+  })
+  .add('secure-random-string', {
+    defer: true,
+    fn: function (defer) {
+      srs(function () { defer.resolve() })
     }
   })
   .add('uid', {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7314,6 +7314,11 @@ schema-utils@^1.0.0:
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
 
+secure-random-string@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/secure-random-string/-/secure-random-string-1.1.0.tgz#c47d2f20b6d93db1255edb4dadf5e03188ab978e"
+  integrity sha512-V/h8jqoz58zklNGybVhP++cWrxEPXlLM/6BeJ4e0a8zlb4BsbYRzFs16snrxByPa5LUxCVTD3M6EYIVIHR1fAg==
+
 semver-compare@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"


### PR DESCRIPTION
secure-random-string has comparable performance for the async API despite
returning 32 characters by default, but is slower in the sync benchmark.

I tried benchmarking returning on 21 characters for a more comparable test, but
it was hardly faster.