### PR TITLE
es module experimental support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules/
 npm-debug.log
 yarn-error.log
 
+/dist-esm
 coverage/
 docs/
 test/demo/build/

--- a/index.browser.js
+++ b/index.browser.js
@@ -1,11 +1,15 @@
+// <disabled-in-es-modules>
 if (process.env.NODE_ENV !== 'production') {
+// </>
   if (typeof self === 'undefined' || (!self.crypto && !self.msCrypto)) {
     throw new Error(
       'Your browser does not have secure random generator. ' +
       'If you don’t need unpredictable IDs, you can use nanoid/non-secure.'
     )
   }
+// <disabled-in-es-modules>
 }
+// </>
 
 var crypto = self.crypto || self.msCrypto
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "url"
   ],
   "scripts": {
+    "prepare": "yarn clean && yarn compile-esm && yarn docs && yarn test",
     "spellcheck": "yarn docs && yaspeller-ci *.md docs/*.html",
     "clean": "rimraf docs/ coverage/",
     "compile-esm": "rimraf dist-esm && babel ./ --out-dir dist-esm --plugins=transform-commonjs --ignore node_modules --ignore dist-esm --ignore coverage --ignore docs --ignore test && eliminate-text-between '// <disabled-in-es-modules>' '// </>' dist-esm/index.browser.js",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "spellcheck": "yarn docs && yaspeller-ci *.md docs/*.html",
     "clean": "rimraf docs/ coverage/",
+    "compile-esm": "rimraf dist-esm && babel ./ --out-dir dist-esm --plugins=transform-commonjs --ignore node_modules --ignore dist-esm --ignore coverage --ignore docs --ignore test",
     "docs": "jsdoc -d docs *.js async/*.js non-secure/*.js",
     "lint": "eslint-ci *.js {async,non-secure,test}/*.js test/{benchmark,alphabet,**/*.js}",
     "test": "jest --coverage && yarn lint && size-limit && yarn spellcheck",
@@ -27,7 +28,10 @@
   },
   "sideEffects": false,
   "devDependencies": {
+    "@babel/cli": "^7.2.3",
+    "@babel/core": "^7.4.0",
     "@logux/eslint-config": "^28.0.0",
+    "babel-plugin-transform-commonjs": "^1.1.5",
     "benchmark": "^2.1.4",
     "chalk": "^2.4.2",
     "clean-publish": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "nanoid",
   "version": "2.0.1",
   "description": "A tiny (141 bytes), secure URL-friendly unique string ID generator",
+  "main": "index.js",
+  "module": "dist-esm/index.browser.js",
   "keywords": [
     "uuid",
     "random",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "spellcheck": "yarn docs && yaspeller-ci *.md docs/*.html",
     "clean": "rimraf docs/ coverage/",
-    "compile-esm": "rimraf dist-esm && babel ./ --out-dir dist-esm --plugins=transform-commonjs --ignore node_modules --ignore dist-esm --ignore coverage --ignore docs --ignore test",
+    "compile-esm": "rimraf dist-esm && babel ./ --out-dir dist-esm --plugins=transform-commonjs --ignore node_modules --ignore dist-esm --ignore coverage --ignore docs --ignore test && eliminate-text-between '// <disabled-in-es-modules>' '// </>' dist-esm/index.browser.js",
     "docs": "jsdoc -d docs *.js async/*.js non-secure/*.js",
     "lint": "eslint-ci *.js {async,non-secure,test}/*.js test/{benchmark,alphabet,**/*.js}",
     "test": "jest --coverage && yarn lint && size-limit && yarn spellcheck",
@@ -35,6 +35,7 @@
     "benchmark": "^2.1.4",
     "chalk": "^2.4.2",
     "clean-publish": "^1.1.0",
+    "eliminate-text-between": "^0.0.4",
     "eslint": "^5.15.3",
     "eslint-ci": "^1.0.0",
     "eslint-config-standard": "^12.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,23 @@
 # yarn lockfile v1
 
 
+"@babel/cli@^7.2.3":
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.2.3.tgz#1b262e42a3e959d28ab3d205ba2718e1923cfee6"
+  integrity sha512-bfna97nmJV6nDJhXNPeEfxyMjWnt6+IjUAaDPiYRTBlm8L41n8nvw6UAqUCbvpFfU246gHPxW7sfWwqtF4FcYA==
+  dependencies:
+    commander "^2.8.1"
+    convert-source-map "^1.1.0"
+    fs-readdir-recursive "^1.1.0"
+    glob "^7.0.0"
+    lodash "^4.17.10"
+    mkdirp "^0.5.1"
+    output-file-sync "^2.0.0"
+    slash "^2.0.0"
+    source-map "^0.5.0"
+  optionalDependencies:
+    chokidar "^2.0.3"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.0.0 <7.4.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"
@@ -29,7 +46,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/core@^7.1.0":
+"@babel/core@^7.1.0", "@babel/core@^7.4.0":
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.4.0.tgz#248fd6874b7d755010bfe61f557461d4f446d9e9"
   integrity sha512-Dzl7U0/T69DFOTwqz/FJdnOSWS57NpjNfCwMKHABr589Lg8uX1RrlBIJ7L5Dubt/xkLsx0xH5EBFzlBVes1ayA==
@@ -1461,6 +1478,13 @@ babel-plugin-jest-hoist@^24.3.0:
   dependencies:
     "@types/babel__traverse" "^7.0.6"
 
+babel-plugin-transform-commonjs@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-commonjs/-/babel-plugin-transform-commonjs-1.1.5.tgz#ba869f27d41318d723eec4700f29add061bb1cba"
+  integrity sha512-UuLVPSZXuBr73UP6cRbQe6EPowMg2Qjelk+xVb/vuSF4a53011DJeqEpiD38i93at4dVLuLuEHBKJxcsHCaTbg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
 babel-preset-jest@^24.3.0:
   version "24.3.0"
   resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-24.3.0.tgz#db88497e18869f15b24d9c0e547d8e0ab950796d"
@@ -2096,7 +2120,7 @@ command-exists@^1.2.6:
   resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.8.tgz#715acefdd1223b9c9b37110a149c6392c2852291"
   integrity sha512-PM54PkseWbiiD/mMsbvW351/u+dafwTJ0ye2qB60G1aGQP9j3xK2gmMDc+R34L3nDtx4qMCitXT75mkbkGJDLw==
 
-commander@^2.11.0, commander@^2.14.1, commander@^2.17.1, commander@^2.18.0, commander@^2.19.0, commander@^2.9.0, commander@~2.19.0:
+commander@^2.11.0, commander@^2.14.1, commander@^2.17.1, commander@^2.18.0, commander@^2.19.0, commander@^2.8.1, commander@^2.9.0, commander@~2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
   integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
@@ -3571,6 +3595,11 @@ fs-minipass@^1.2.5:
   dependencies:
     minipass "^2.2.1"
 
+fs-readdir-recursive@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz#e32fc030a2ccee44a6b5371308da54be0b397d27"
+  integrity sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==
+
 fs-write-stream-atomic@^1.0.8:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz#b47df53493ef911df75731e70a9ded0189db40c9"
@@ -3684,7 +3713,7 @@ glob-to-regexp@^0.3.0:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
 
-glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
+glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
@@ -4338,6 +4367,11 @@ is-path-inside@^1.0.0:
   integrity sha1-jvW33lBDej/cprToZe96pVy0gDY=
   dependencies:
     path-is-inside "^1.0.1"
+
+is-plain-obj@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
+  integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
 
 is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
@@ -6023,6 +6057,15 @@ osenv@^0.1.4:
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
+
+output-file-sync@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/output-file-sync/-/output-file-sync-2.0.1.tgz#f53118282f5f553c2799541792b723a4c71430c0"
+  integrity sha512-mDho4qm7WgIXIGf4eYU1RHN2UU5tPfVYVSRwDJw0uTmj35DQUt/eNp19N7v6T3SrR0ESTEf2up2CGO73qI35zQ==
+  dependencies:
+    graceful-fs "^4.1.11"
+    is-plain-obj "^1.1.0"
+    mkdirp "^0.5.1"
 
 p-defer@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2706,6 +2706,11 @@ detect-newline@^2.1.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
   integrity sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=
 
+die-on-error@0.0.0-dev.0:
+  version "0.0.0-dev.0"
+  resolved "https://registry.yarnpkg.com/die-on-error/-/die-on-error-0.0.0-dev.0.tgz#0c865af670a8f7c1ad9b1a9ff7ed4c8392c0ab2f"
+  integrity sha512-Fzb4MRPT1CBGsANSouNNtfanvT8YXovWAu8lXE2aS2NNjsYn2N0qxozRHA8OtQ1KOKQXV+fe6/HJfv3D6U7kHA==
+
 diff-sequences@^24.3.0:
   version "24.3.0"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.3.0.tgz#0f20e8a1df1abddaf4d9c226680952e64118b975"
@@ -2859,6 +2864,15 @@ elegant-spinner@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
   integrity sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=
+
+eliminate-text-between@^0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/eliminate-text-between/-/eliminate-text-between-0.0.4.tgz#4e4658abb9fb4cede2e24d87face3bd302cdc360"
+  integrity sha512-VD8QzXDEExzMUH2KKJsCF7XyfUwAi44Th8kVn8qYBP/2TRBIOucfaEnxc4L+e4XAcEmV/hCTaFMe9EbwbaRCWg==
+  dependencies:
+    die-on-error "0.0.0-dev.0"
+    fancyfs "^0.1.0"
+    glob "^7.1.3"
 
 elliptic@^6.0.0:
   version "6.4.1"
@@ -3364,6 +3378,11 @@ falafel@^2.1.0:
     foreach "^2.0.5"
     isarray "0.0.1"
     object-keys "^1.0.6"
+
+fancyfs@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/fancyfs/-/fancyfs-0.1.0.tgz#0b32bab2764f676a17f7085f58e9c6c6a0ddb63d"
+  integrity sha512-mEkD0Vso/qaS97yuDmc0L/M4tH1LRQxvpxTo0xZhW3wzw+b5oBxUP+uAYR5YlPCKct7Od+464Inpy19c5ZRQsA==
 
 fast-deep-equal@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
hello friends,

i wanted to take a fresh approach to implementing es modules in nanoid

i've done this for my own (largely-educational) reasons.  
i'm not expecting this to be merged unless you feel it serves nanoid's purposes... i'm merely fascinated with the topic :)

improvements over the previous esm branch:
- es modules appear in the new `dist-esm` directory
- commonjs modules are left as-is
- no breaking changes for consumers
- all checks are passing (lint/size-limit/spelling/tests)
- add "prepare" script to package.json to organize compilation with checks, and ensure the project is prepared before each publish

beware, the second commit 74d7573 has a very questionable hack to remove the 'process' code in the es-module version (related to #118)