### PR TITLE
Adds documentation for react-native using expo

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,22 +185,7 @@ Nano ID could be started from number. HTML ID can’t be started from the numbe
 
 ### React Native
 
-To generate secure random IDs in React Native, you must use
-[a native random generator] and asynchronous API:
-
-```js
-const generateSecureRandom = require('react-native-securerandom').generateSecureRandom
-const format = require('nanoid/async/format')
-const url = require('nanoid/url')
-
-async function createUser () {
-  user.id = await format(generateSecureRandom, url, 21);
-}
-```
-
-#### Expo
-
-If you are using expo, you can not use [a native random generator] because it requires native-linking. Anyway you can use [expo-random] as the secure number generator.
+To generate secure random IDs in React Native, you must use a native random generator (like [expo-random] or [react-native-securerandom]) and the asynchronous API:
 
 ```ts
 import { getRandomBytesAsync } from 'expo-random';
@@ -213,10 +198,8 @@ const random = (getRandomBytesAsync as unknown) as (byteCount: number) => Promis
 export const id = async () => format(random, url, 21);
 ```
 
-Also, if you don't need secure id's there is still the non-secure version, which does not require a secure number generator (only use if you don't care about predictable IDs).
-
 [expo-random]: https://github.com/expo/expo/tree/master/packages/expo-random
-[a native random generator]: https://github.com/rh389/react-native-securerandom
+[react-native-securerandom]: https://github.com/rh389/react-native-securerandom
 
 
 ### PouchDB and CouchDB

--- a/README.md
+++ b/README.md
@@ -189,12 +189,14 @@ To generate secure random IDs in React Native, you must use a native random
 generator (like [expo-random] or [react-native-securerandom]) and the
 asynchronous API:
 
-```ts
-import { getRandomBytesAsync } from 'expo-random';
-import format from 'nanoid/async/format';
-import url from 'nanoid/url';
+```js
+const getRandomBytesAsync = require('expo-random').getRandomBytesAsync
+const format = require('nanoid/async/format')
+const url = require('nanoid/url')
 
-export const id = () => format(getRandomBytesAsync, url, 21);
+async function createUser () {
+  user.id = await format(getRandomBytesAsync, url, 21);
+}
 ```
 
 [expo-random]: https://github.com/expo/expo/tree/master/packages/expo-random

--- a/README.md
+++ b/README.md
@@ -198,6 +198,24 @@ async function createUser () {
 }
 ```
 
+#### Expo
+
+If you are using expo, you can not use [a native random generator] because it requires native-linking. Anyway you can use [expo-random] as the secure number generator.
+
+```ts
+import { getRandomBytesAsync } from 'expo-random';
+import format from 'nanoid/async/format';
+import url from 'nanoid/url';
+
+// Only required if you use TypeScript to tell the compiler that the types are compatible.
+const random = (getRandomBytesAsync as unknown) as (byteCount: number) => Promise<number[]>;
+
+export const id = async () => format(random, url, 21);
+```
+
+Also, if you don't need secure id's there is still the non-secure version, which does not require a secure number generator (only use if you don't care about predictable IDs).
+
+[expo-random]: https://github.com/expo/expo/tree/master/packages/expo-random
 [a native random generator]: https://github.com/rh389/react-native-securerandom
 
 

--- a/README.md
+++ b/README.md
@@ -185,17 +185,16 @@ Nano ID could be started from number. HTML ID can’t be started from the numbe
 
 ### React Native
 
-To generate secure random IDs in React Native, you must use a native random generator (like [expo-random] or [react-native-securerandom]) and the asynchronous API:
+To generate secure random IDs in React Native, you must use a native random 
+generator (like [expo-random] or [react-native-securerandom]) and the
+asynchronous API:
 
 ```ts
 import { getRandomBytesAsync } from 'expo-random';
 import format from 'nanoid/async/format';
 import url from 'nanoid/url';
 
-// Only required if you use TypeScript to tell the compiler that the types are compatible.
-const random = (getRandomBytesAsync as unknown) as (byteCount: number) => Promise<number[]>;
-
-export const id = async () => format(random, url, 21);
+export const id = () => format(getRandomBytesAsync, url, 21);
 ```
 
 [expo-random]: https://github.com/expo/expo/tree/master/packages/expo-random

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Nano ID could be started from number. HTML ID can’t be started from the numbe
 ### React Native
 
 To generate secure random IDs in React Native, you must use a native random 
-generator (like [expo-random] or [react-native-securerandom]) and the
+generator (like [`expo-random`] or [`react-native-securerandom`]) and the
 asynchronous API:
 
 ```js
@@ -199,8 +199,8 @@ async function createUser () {
 }
 ```
 
-[expo-random]: https://github.com/expo/expo/tree/master/packages/expo-random
-[react-native-securerandom]: https://github.com/rh389/react-native-securerandom
+[`expo-random`]: https://github.com/expo/expo/tree/master/packages/expo-random
+[`react-native-securerandom`]: https://github.com/rh389/react-native-securerandom
 
 
 ### PouchDB and CouchDB


### PR DESCRIPTION
I added some documentation how to use nanoid with react-native when using expo. Had to search a while to find `expo-random` and to get nanoid up and running, so I thought it would be worth sharing in the documentation.