### PR TITLE
Allow react-native alternative for a async random number generator

### DIFF
--- a/async/random.reactnative.js
+++ b/async/random.reactnative.js
@@ -1,0 +1,18 @@
+var expoRandom
+
+try {
+  /* eslint-disable-next-line global-require, node/no-missing-require */
+  expoRandom = require('expo-random')
+} catch (importError) {}
+
+module.exports = function (bytes) {
+  if (!expoRandom) {
+    throw new Error(
+      'React-Native does not have a built-in secure random generator. ' +
+      'Install "expo-random" locally or ' +
+      'if you don’t need unpredictable IDs, you can use `nanoid/non-secure`.'
+    )
+  }
+
+  return expoRandom.getRandomBytesAsync(new Uint8Array(bytes))
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "./async/index.js": "./async/index.browser.js",
     "./async/random.js": "./async/random.browser.js"
   },
+  "react-native": {
+    "./async/random.js": "./async/random.reactnative.js"
+  },
   "sideEffects": false,
   "devDependencies": {
     "@logux/eslint-config": "^30.0.2",


### PR DESCRIPTION
My colleagues are building a react-native application. We use `nanoid` as part of our login flow. While introducing our common solution I got an issues reported that the current usage of `nanoid` breaks the application for them. The reason for this is the exception which is being thrown in `index.browser.js`. (Interestingly the same exception should be probably added to the async layer - which is not yet implemented.) Back to the issue. We could probably think of adding [a `react-native` entry](https://github.com/facebook/metro/blob/a29d30327365f3f52652f68d53896355021cc693/packages/metro/src/node-haste/Package.js#L45) as supported by the Metro bundler (used by React Native) to use a special random number generator in async. 

For our login flow I am fine with using the async API. But still this has to work without throwing errors in React Native. 

The solution described in the Readme is a good solution for plain react-native projects, but does not correctly work in these cross-target libraries. I do not want to make any native code for iOS/Android a dependency to our pure JS library. 

So I wondered how this can be probably look like for `nanoid` if supported out of the box. I just replaced the random number generator with the code listed in the readme. Do you think it would be that simple? 

This PR is meant as a suggestions and discussion starting point. Thanks for listening.