### PR TITLE
Add missing word on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ async function createUser () {
 
 ### PouchDB and CouchDB
 
-In PouchDB and CouchDB, IDs can’t with an underscore `_`.
+In PouchDB and CouchDB, IDs can’t start with an underscore `_`.
 A prefix is required to prevent this issue, as Nano ID might use a `_`
 at the start of the ID by default.
 


### PR DESCRIPTION
Add the missing word "start" on "PouchDB and CouchDB" section of README