### PR TITLE
Updated link to py-nanoid-dictionary

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ ID generators on client and server side.
 * [Java](https://github.com/aventrix/jnanoid)
 * [Nim](https://github.com/icyphox/nanoid.nim)
 * [PHP](https://github.com/hidehalo/nanoid-php)
-* [Python](https://github.com/puyuan/py-nanoid) with [dictionaries](https://github.com/aidarkhanov/py-nanoid-dictionary)
+* [Python](https://github.com/puyuan/py-nanoid) with [dictionaries](https://pypi.org/project/nanoid-dictionary)
 * [Ruby](https://github.com/radeno/nanoid.rb)
 * [Rust](https://github.com/nikolay-govorov/nanoid)
 * [Swift](https://github.com/antiflasher/NanoID)


### PR DESCRIPTION
Hello! The working link to py-nanoid-dictionary has changed as the library is no longer available on Github.