### PR TITLE
Fix react native usage

### DIFF
--- a/async/random.rn.js
+++ b/async/random.rn.js
@@ -10,5 +10,5 @@ try {
 }
 
 module.exports = function (bytes) {
-  return random.getRandomBytesAsync(new Uint8Array(bytes))
+  return random.getRandomBytesAsync(bytes)
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "./async/random.js": "./async/random.browser.js"
   },
   "react-native": {
-    "./async/random.js": "./random.rn.js"
+    "./async/random.js": "./async/random.rn.js"
   },
   "sideEffects": false,
   "devDependencies": {


### PR DESCRIPTION
Some small fixes for react native.

Maybe its a Windows thing, but the path for the `random.rn.js` in `package.json` should be relative to the root.

> Unable to resolve "./random" from "node_modules\nanoid\async\index.js"

Also, the call to `expo-random` was a bit off.

> [Unhandled promise rejection: TypeError: expo-random: getRandomBytesAsync(0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0) expected a valid number from range 0...1024]

Correct method signature is: `getRandomBytesAsync(byteCount: number): Promise<Uint8Array>`