### PR TITLE
Improve performance by removing extra comparison

### DIFF
--- a/index.browser.js
+++ b/index.browser.js
@@ -26,8 +26,8 @@ module.exports = function (size) {
   size = size || 21
   var id = ''
   var bytes = crypto.getRandomValues(new Uint8Array(size))
-  while (0 < size--) {
-    id += url[bytes[size] & 63]
+  while (size--) {
+    id = id + url[bytes[size] & 63]
   }
   return id
 }


### PR DESCRIPTION
This isn't a huge gain, but ran across these while doing some other testing.

In the browser version while loop, I believe there is an extra comparison `0 <`. 
Also, I've found using `+=` reduces performance ~4k-6k/sec.

Showing improvements of ~10k-80k/sec (or randomly 1.5million/sec when the stars align) depending on browser (needs more testing).

#### Changes

`index.browser.js`

```js
// Original 
while (0 < size--) {
  id += url[bytes[size] & 63]
}

// Modified
while (size--) {
  id = id + url[bytes[size] & 63]
}

```

#### Benchmark Link
View benchmarks on jsPerf
**[64 length](https://jsperf.com/nano-id-browser-optimizations/1)**
**[21 length](https://jsperf.com/nano-id-browser-optimizations/2)**

(shorter lengths have more variance/unstable)

#### Notes

In the benchmarks link, I explored using modulo vs the bitwise `&` and caching the url string length into a variable. On average, the best combination across 3 browsers was removing the extra `0 <` comparison and replacing `+=` with explicit assignment.