### PR TITLE
Speedup mask calculation in format

### DIFF
--- a/format.js
+++ b/format.js
@@ -27,17 +27,19 @@
  * @function
  */
 module.exports = function (random, alphabet, size) {
-  var mask = (2 << Math.log(alphabet.length - 1) / Math.LN2) - 1
-  var step = Math.ceil(1.6 * mask * size / alphabet.length)
   size = +size
-
+  var len = alphabet.length
+  var mask = (2 << 31 - Math.clz32((len - 1) | 1)) - 1
+  var step = Math.ceil(1.6 * mask * size / len)
   var id = ''
+
   while (true) {
     var bytes = random(step)
     for (var i = 0; i < step; i++) {
       var byte = bytes[i] & mask
-      if (alphabet[byte]) {
-        id += alphabet[byte]
+      var alpha = alphabet[byte]
+      if (alpha) {
+        id += alpha
         if (id.length === size) return id
       }
     }

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     },
     {
       "path": "generate.js",
-      "limit": "180 B"
+      "limit": "182 B"
     },
     {
       "path": "url.js",


### PR DESCRIPTION
- replace emulated integer `log2(x)` to `31 - clz(x)` which should speed up bust formatting
- move `size = +size` before it first usage

Coveats: **+2 bytes**