### PR TITLE
use .bind to reduce bundle 2b more

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -19,6 +19,4 @@ var format = require('./format')
  * @name generate
  * @function
  */
-module.exports = function (alphabet, size) {
-  return format(random, alphabet, size)
-}
+module.exports = format.bind(null, random)


### PR DESCRIPTION
I'm unsure about whether you want to use .bind - but from my point of view it is pretty usable (IE9+, even more than getRandomValues reference) and somehow exactly `null` (neither `undefined` nor `0` or whatever) produces 2kb less.