### PR TITLE
Reverse format for cycle

### DIFF
--- a/async/format.js
+++ b/async/format.js
@@ -35,7 +35,7 @@ module.exports = function (random, alphabet, size) {
 
   function tick (id) {
     return random(step).then(function (bytes) {
-      for (var i = 0; i < step; i++) {
+      for (var i = step; i--;) {
         var byte = bytes[i] & mask
         if (alphabet[byte]) {
           id += alphabet[byte]

--- a/format.js
+++ b/format.js
@@ -34,7 +34,7 @@ module.exports = function (random, alphabet, size) {
   var id = ''
   while (true) {
     var bytes = random(step)
-    for (var i = 0; i < step; i++) {
+    for (var i = step; i--;) {
       var byte = bytes[i] & mask
       if (alphabet[byte]) {
         id += alphabet[byte]

--- a/test/async-format.test.js
+++ b/test/async-format.test.js
@@ -10,7 +10,7 @@ it('generates random string', async () => {
     return bytes
   }
   let id = await format(random, 'abcde', 4)
-  expect(id).toEqual('cdac')
+  expect(id).toEqual('adca')
 })
 
 it('is ready for errors', async () => {

--- a/test/format.test.js
+++ b/test/format.test.js
@@ -9,5 +9,5 @@ it('generates random string', () => {
     }
     return bytes
   }
-  expect(format(random, 'abcde', 4)).toEqual('cdac')
+  expect(format(random, 'abcde', 4)).toEqual('adca')
 })


### PR DESCRIPTION
>   generate.js
>   Size limit: 180 B
>   Size:       **177** B with all dependencies, minified and gzipped

>   async/generate.js
>   Size limit: 201 B
>   Size:       **199** B with all dependencies, minified and gzipped

This PR changes logic for `format` function a bit, but... This is «_random_ string generator» eventually, I guess, this change will not break, well, _randomness_.
I also have changed tests for new results.