### PR TITLE
chore: remove microtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "husky": "^3.0.8",
     "jest": "^24.9.0",
     "lint-staged": "^9.4.2",
-    "microtime": "^3.0.0",
     "parcel-bundler": "^1.12.4",
     "rimraf": "^3.0.0",
     "rndm": "^1.2.0",


### PR DESCRIPTION
Microtime is not used anywhere and breaks project scaffolding in Windows.