### PR TITLE
The same behavior in nodejs and browsers.

### DIFF
--- a/async/index.browser.js
+++ b/async/index.browser.js
@@ -9,7 +9,7 @@ var crypto = self.crypto || self.msCrypto
 var url = 'IUint8Ar21ModulvezGFYPCJ7_p0V4XSymbLBNH6fTqQ35xD9ZREghasOw-cjkWK'
 
 module.exports = function (size) {
-  size = size || 21
+  size = size | 0 || 21
   var id = ''
   var bytes = crypto.getRandomValues(new Uint8Array(size))
   // Compact alternative for `for (var i = 0; i < size; i++)`

--- a/async/index.js
+++ b/async/index.js
@@ -21,7 +21,7 @@ var url = require('../url')
  * @function
  */
 module.exports = function (size) {
-  size = size || 21
+  size = size | 0 || 21
   return random(size).then(function (bytes) {
     var id = ''
     // Compact alternative for `for (var i = 0; i < size; i++)`

--- a/index.browser.js
+++ b/index.browser.js
@@ -26,7 +26,7 @@ var crypto = self.crypto || self.msCrypto
 var url = 'QLUint8ARdomValuesObj0h6345-79BCrypgJzHKTNYDSMkXPZ_FfG1WcqvwxEI2'
 
 module.exports = function (size) {
-  size = size || 21
+  size = size | 0 || 21
   var id = ''
   var bytes = crypto.getRandomValues(new Uint8Array(size))
   // Compact alternative for `for (var i = 0; i < size; i++)`

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ var url = require('./url')
  * @function
  */
 module.exports = function (size) {
-  size = size || 21
+  size = size | 0 || 21
   var bytes = random(size)
   var id = ''
   // Compact alternative for `for (var i = 0; i < size; i++)`

--- a/non-secure/index.js
+++ b/non-secure/index.js
@@ -19,7 +19,7 @@ var url = 'sOwnPropMN49CEiq-hXvHJdSymlFURTag61GQfuD8YIWz2Zk5xKB7LV30_Abject'
  * @function
  */
 module.exports = function (size) {
-  size = size || 21
+  size = size | 0 || 21
   var id = ''
   // Compact alternative for `for (var i = 0; i < size; i++)`
   while (size--) {

--- a/test/async.test.js
+++ b/test/async.test.js
@@ -46,14 +46,8 @@ it('changes ID length', async () => {
   expect(id).toHaveLength(10)
 })
 
-it('throws on string', async () => {
-  let error
-  try {
-    await async('10')
-  } catch (e) {
-    error = e
-  }
-  expect(error.message).toContain('"size" argument must be')
+it('accepts string', async () => {
+  await expect(async('10')).resolves.toHaveLength(10)
 })
 
 it('has no collisions', async () => {
@@ -100,4 +94,10 @@ it('rejects Promise on error', async () => {
     catched = e
   }
   expect(catched).toBe(error)
+})
+
+it('should cast wrong types to deafults', async () => {
+  await expect(async('foobar')).resolves.toHaveLength(21)
+  await expect(async({})).resolves.toHaveLength(21)
+  await expect(async('10foo')).resolves.toHaveLength(21)
 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -53,3 +53,9 @@ it('has flat distribution', () => {
   }
   expect(max - min).toBeLessThanOrEqual(0.05)
 })
+
+it('should cast wrong types to deafults', () => {
+  expect(nanoid('foobar')).toHaveLength(21)
+  expect(nanoid({})).toHaveLength(21)
+  expect(nanoid('10foo')).toHaveLength(21)
+})


### PR DESCRIPTION
I found that `nanoid` has different behavior in nodejs and browsers. Details:

## Before

* nodejs, sync
```
nanoid('10') // throw TypeError (test was broken)
			 // works fine if it was called after nanoid(10)
  			 // this is possible due to buffers[10] === buffers['10']
nanoid('foobar') // throw TypeError
```

* nodejs, async
```
nanoid('10') // throw TypeError always
nanoid('foobar') // throw TypeError
```

* browser, sync
```
nanoid('10') // works as nanoid(10)
nanoid('foobar') // return empty string
				 // new Uint8Array('foobar') allocates empty array
				 // while('foobar'--) {} is false
```

* browser, async
works as sync

## After

All versions works like:

```
nanoid('10') // works as nanoid(10)
nanoid('foobar') // works as nanoid()
```

It cost 2 bytes.

---

`nanoid/random` also has differend behavior, but i leave it for next pr / discussion.