### PR TITLE
Non-secure: Generate alphabet using fromCharCode

### DIFF
--- a/non-secure/index.js
+++ b/non-secure/index.js
@@ -1,7 +1,25 @@
-// This alphabet uses a-z A-Z 0-9 _- symbols. Symbols order was changed
-// for better gzip compression. We use genetic algorithm to find the best order.
-// Check generator code at test/alphabet-genetic.
-var url = 'sOwnPropMN49CEiq-hXvHJdSymlFURTag61GQfuD8YIWz2Zk5xKB7LV30_Abject'
+// This alphabet uses a-z A-Z 0-9 _- symbols.
+// Despite the fact the source code is quite long, its entropy
+// is low and there are lots of duplicates - just what compressors
+// like GZIP and Brotli likes the best.
+var i
+var url = '_-' + String.fromCharCode(
+  // ASCII codes for 0...9
+  i = 48, i += 1, i += 1, i += 1, i += 1, i += 1, i += 1, i += 1,
+  i += 1, i += 1,
+
+  // ASCII codes for A...Z
+  i += 8, i += 1, i += 1, i += 1, i += 1, i += 1, i += 1, i += 1,
+  i += 1, i += 1, i += 1, i += 1, i += 1, i += 1, i += 1, i += 1,
+  i += 1, i += 1, i += 1, i += 1, i += 1, i += 1, i += 1, i += 1,
+  i += 1, i += 1,
+
+  // ASCII codes for a...z
+  i += 7, i += 1, i += 1, i += 1, i += 1, i += 1, i += 1, i += 1,
+  i += 1, i += 1, i += 1, i += 1, i += 1, i += 1, i += 1, i += 1,
+  i += 1, i += 1, i += 1, i += 1, i += 1, i += 1, i += 1, i += 1,
+  i += 1, i += 1
+)
 
 /**
  * Generate URL-friendly unique ID. This method use non-secure predictable

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     },
     {
       "path": "non-secure/index.js",
-      "limit": "102 B"
+      "limit": "89 B"
     },
     {
       "path": "non-secure/generate.js",


### PR DESCRIPTION
102 -> 89 (-13) bytes for `non-secure/index.js`

----

This can go down to 87 if the `url` variable is reused as `i`:

```
var url =  String.fromCharCode(
  url = 48, url += 1, url += 1, ...
```

There are downsides though:

- eslint rants about a _variable is used before before it was defined_.

- This way the `url` variable changes its type from `number` to `string` in the runtime. At least V8 could JIT the code worse when it encounters a non-monomorphic variable.