### PR TITLE
do not reference secure js in non-secure js

### DIFF
--- a/non-secure/index.js
+++ b/non-secure/index.js
@@ -1,4 +1,5 @@
-let { urlAlphabet } = require('..')
+let urlAlphabet =
+  '_-0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
 
 let customAlphabet = (alphabet, size) => {
   return () => {


### PR DESCRIPTION
do not reference secure js in non-secure js, since it will force the bundler to require `crypto`.