### PR TITLE
Update index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,7 +21,7 @@ export function nanoid (size?: number): string
  * will not be secure.
  *
  * @param alphabet Alphabet used to generate the ID.
- * @param size Size of the ID. The default size is 21.
+ * @param size Size of the ID.
  * @returns A random string generator.
  *
  * ```js


### PR DESCRIPTION
Since this parameter doesn't appear to be optional for the `customAlphabet` function, we should either remove the `The default size is 21.` from the documentation or update the code to default to a size of `21` if it's not passed in. This PR does the former, but the intent is more to prompt a discussion. Also, please let me know if I'm missing something 😄

Thanks in advance!