### PR TITLE
fix: avoid require bug in node.js 13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "author": "Andrey Sitnik <andrey@sitnik.ru>",
   "license": "MIT",
   "repository": "ai/nanoid",
+  "main": "./index.js",
   "browser": {
     "./index.js": "./index.browser.js",
     "./async/index.js": "./async/index.browser.js"


### PR DESCRIPTION
https://github.com/nodejs/modules/issues/446

    "Error: Package exports for '/data/data/com.termux/files/home/.config/yarn/global/node_modules/nanoid' do not define a valid '.' target\n"

![Screenshot_20200412-121017_Termux](https://user-images.githubusercontent.com/167966/79060382-ff757000-7cb6-11ea-8236-516e8f00c782.jpg)
