### PR TITLE
Restrict failing node@13.x versions at engines.node

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,5 +186,8 @@
   "sharec": {
     "config": "@logux/sharec-config",
     "version": "0.6.2"
+  },
+  "engines": {
+    "node": "^10 || ^12 || >=13.7"
   }
 }


### PR DESCRIPTION
~~Since @ai mentioned we only support `^10`, `^12`, and `>=13`, I didn't include `^11`. But if there is no reason not to support `^11` (as far as I can tell it actually works), we can update the semver as `">=10 <13 || >=13.7"`.~~

Nvm, I didn't realize Node disowned `11` 😂 

Alright this fixes https://github.com/ai/nanoid/issues/215