### PR TITLE
Added C++ implementation reference to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,7 @@ Nano ID was ported to many languages. You can use these ports to have
 the same ID generator on the client and server side.
 
 * [C#](https://github.com/codeyu/nanoid-net)
+* [C++](https://github.com/mcmikecreations/nanoid_cpp)
 * [Clojure and ClojureScript](https://github.com/zelark/nano-id)
 * [Crystal](https://github.com/mamantoha/nanoid.cr)
 * [Dart](https://github.com/pd4d10/nanoid-dart)


### PR DESCRIPTION
Put a link to C++ implementation of nanoid at the "Other Programming Languages" part of README.