### PR TITLE
async/customAlphabet - ensure browser version returns Promise

### DIFF
--- a/async/index.browser.js
+++ b/async/index.browser.js
@@ -35,7 +35,7 @@ let customAlphabet = (alphabet, size) => {
         // Adding `|| ''` refuses a random byte that exceeds the alphabet size.
         id += alphabet[bytes[i] & mask] || ''
         // `id.length + 1 === size` is a more compact option.
-        if (id.length === +size) return id
+        if (id.length === +size) return Promise.resolve(id)
       }
     }
   }


### PR DESCRIPTION
To ensure consistency in the functions exported by async/browser.index
and to not catch out users expecting a Thenable returned by functions
claimed to be async, ensure that the final value returned by 
`customAlphabet()` is a Promise resolving to the value, not the value
itself

Fixes #228 