### PR TITLE
Browser: Generate random numbers in larger request sizes

### DIFF
--- a/index.browser.js
+++ b/index.browser.js
@@ -40,8 +40,6 @@ if (process.env.NODE_ENV !== 'production') {
 const POOL_SIZE_MULTIPLIER = 32
 let pool, poolOffset
 
-console.log('hello')
-
 let random = bytes => {
   if (!pool || pool.length < bytes) {
     pool = new Uint8Array(bytes * POOL_SIZE_MULTIPLIER)

--- a/package.json
+++ b/package.json
@@ -76,12 +76,12 @@
     {
       "name": "nanoid",
       "import": "{ nanoid }",
-      "limit": "108 B"
+      "limit": "192 B"
     },
     {
       "name": "customAlphabet",
       "import": "{ customAlphabet }",
-      "limit": "142 B"
+      "limit": "192 B"
     },
     {
       "name": "urlAlphabet",


### PR DESCRIPTION
Before
===
<img width="865" alt="Screen Shot 2020-10-26 at 10 16 55 AM" src="https://user-images.githubusercontent.com/916345/97184265-1b34f500-1775-11eb-943f-2be0c35d9a22.png">

After
===
<img width="825" alt="Screen Shot 2020-10-26 at 10 23 02 AM" src="https://user-images.githubusercontent.com/916345/97184540-69e28f00-1775-11eb-9985-c0c297a17cdb.png">

