### PR TITLE
Fix custom random return condition

### DIFF
--- a/async/index.browser.js
+++ b/async/index.browser.js
@@ -34,8 +34,8 @@ let customAlphabet = (alphabet, size) => {
       while (i--) {
         // Adding `|| ''` refuses a random byte that exceeds the alphabet size.
         id += alphabet[bytes[i] & mask] || ''
-        // `id.length + 1 === size` is a more compact option.
-        if (id.length === +size) return Promise.resolve(id)
+        // Return if id length equals size.
+        if (id.length === size) return Promise.resolve(id)
       }
     }
   }

--- a/async/index.js
+++ b/async/index.js
@@ -45,8 +45,8 @@ let customAlphabet = (alphabet, size) => {
       while (i--) {
         // Adding `|| ''` refuses a random byte that exceeds the alphabet size.
         id += alphabet[bytes[i] & mask] || ''
-        // `id.length + 1 === size` is a more compact option.
-        if (id.length === +size) return id
+        // Return if id length equals size.
+        if (id.length === size) return id
       }
       return tick(id)
     })

--- a/async/index.native.js
+++ b/async/index.native.js
@@ -31,8 +31,8 @@ let customAlphabet = (alphabet, size) => {
       while (i--) {
         // Adding `|| ''` refuses a random byte that exceeds the alphabet size.
         id += alphabet[bytes[i] & mask] || ''
-        // `id.length + 1 === size` is a more compact option.
-        if (id.length === +size) return id
+        // Return if id length equals size.
+        if (id.length === size) return id
       }
       return tick(id)
     })

--- a/index.browser.js
+++ b/index.browser.js
@@ -67,8 +67,8 @@ let customRandom = (alphabet, size, getRandom) => {
       while (j--) {
         // Adding `|| ''` refuses a random byte that exceeds the alphabet size.
         id += alphabet[bytes[j] & mask] || ''
-        // `id.length + 1 === size` is a more compact option.
-        if (id.length === +size) return id
+        // Return if id length equals size.
+        if (id.length === size) return id
       }
     }
   }

--- a/index.js
+++ b/index.js
@@ -54,8 +54,8 @@ let customRandom = (alphabet, size, getRandom) => {
       while (i--) {
         // Adding `|| ''` refuses a random byte that exceeds the alphabet size.
         id += alphabet[bytes[i] & mask] || ''
-        // `id.length + 1 === size` is a more compact option.
-        if (id.length === +size) return id
+        // Return if id length equals size.
+        if (id.length === size) return id
       }
     }
   }


### PR DESCRIPTION
We want to return the id when the length of the id equals the desired size.

This fixes the annotation as it is not changing the outcome; The plus doesn't change the expression `1 === +1 // true`.