### PR TITLE
Improve Rollup usage documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,17 +273,22 @@ For Expo framework see the next section.
 
 ### Rollup
 
-For Rollup you will need [`@rollup/plugin-replace`] to replace
+For Rollup you will need [`@rollup/plugin-node-resolve`] to bundle browser version
+of this library and [`@rollup/plugin-replace`] to replace
 `process.env.NODE_ENV`:
 
 ```js
   plugins: [
+    nodeResolve({
+      browser: true
+    }),
     replace({
-      'process.env.NODE_ENV': JSON.stringify(process.env.NODE)
+      'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV)
     })
   ]
 ```
 
+[`@rollup/plugin-node-resolve`]: https://github.com/rollup/plugins/tree/master/packages/node-resolve
 [`@rollup/plugin-replace`]: https://github.com/rollup/plugins/tree/master/packages/replace
 
 


### PR DESCRIPTION
I have an React component library, which is bundled with Rollup. Then this library is used with app bundled with webpack. After importing `nanoid` in this library and bundling with Rollup. Webpack then adds 590.15kb of Node.js polyfill to the bundle.

The reason is Rollup bundles `index.js`, which has `import crypto from 'crypto'`. When I configure Rollup `node-resolve` plugin to search for `browser` field, then `index.browser.js` imported into bundle.

I thought update of documentation could help other developers.