### PR TITLE
Fix NodeJs example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ model.id = nanoid() //=> "V1StGXR8_Z5jdHi6B-myT"
 In Node.js you can use CommonJS import:
 
 ```js
-const { nanoid } = require('nanoid')
+const nanoid = require('nanoid')
 ```
 
 If you want to reduce the ID size (and increase collisions probability),


### PR DESCRIPTION
The README shows

```js
const { nanoid } = require('nanoid')
```

which causes the call `nanoid()` to crash in NodeJS with the error: `TypeError: nanoid is not a function`

Fixed by removing the braces

```js
const nanoid = require('nanoid')
```