### PR TITLE
feat: Re-optimize the alphabet for gzip after size-limit update

### DIFF
--- a/non-secure/index.js
+++ b/non-secure/index.js
@@ -1,7 +1,7 @@
-// This alphabet uses `A-Za-z0-9_-` symbols. The genetic algorithm helped
-// optimize the gzip compression for this alphabet.
+// This alphabet uses `A-Za-z0-9_-` symbols.
+// The order of characters is optimized for better gzip compression
 let urlAlphabet =
-  'ModuleSymbhasOwnPr-0123456789ABCDEFGHNRVfgctiUvz_KqYTJkLxpZXIjQW'
+  'useandom-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_bfghjklpqvwxyzrict'
 
 let customAlphabet = (alphabet, size) => {
   return () => {

--- a/url-alphabet/index.js
+++ b/url-alphabet/index.js
@@ -1,6 +1,6 @@
-// This alphabet uses `A-Za-z0-9_-` symbols. The genetic algorithm helped
-// optimize the gzip compression for this alphabet.
+// This alphabet uses `A-Za-z0-9_-` symbols.
+// The order of characters is optimized for better gzip compression
 let urlAlphabet =
-  'ModuleSymbhasOwnPr-0123456789ABCDEFGHNRVfgctiUvz_KqYTJkLxpZXIjQW'
+  'use-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abdfghjklmnopqvwxyzrict'
 
 module.exports = { urlAlphabet }


### PR DESCRIPTION
Now that after the size-limit update the exports are tree-shaked and the alphabet should be re-optimized for gzip.
For `urlAlphabet` The only string for the backreferences we can rely on is `"use strict"`, so the new alphabet is

`'use` ... `rict'`

_Notice the the string quotes are the part of the backreferences, too. I really hope the minifier would use the same quotes both for `"use strict"` and the alphabet string._

For `non-secure nanoid`, the opttimization is just better-than nothing. So I guess compression enthusiasts can improve it further.

```
  urlAlphabet
  Package size is 5 B less than limit
  Size limit: 66 B
  Size:       61 B with all dependencies, minified and gzipped
  
  non-secure nanoid
  Package size is 6 B less than limit
  Size limit: 124 B
  Size:       118 B with all dependencies, minified and gzipped
```
