### PR TITLE
feat: Re-optimize alphabet for Brotli (only chars unused by gzip backrefs)

### DIFF
--- a/non-secure/index.js
+++ b/non-secure/index.js
@@ -1,7 +1,11 @@
 // This alphabet uses `A-Za-z0-9_-` symbols.
-// The order of characters is optimized for better gzip compression
+// The order of characters is optimized for better gzip and brotli compression.
+// References to the same file (works both for gzip and brotli):
+// `'use`, `andom`, and `rict'`
+// References to the brotli default dictionary:
+// `-26T`, `1983`, `40px`, `75px`, `bush`, `jack`, `mind`, `very`, and `wolf`
 let urlAlphabet =
-  'useandom-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_bfghjklpqvwxyzrict'
+  'useandom-26T198340PX75pxJACKVERYMINDBUSHWOLF_GQZbfghjklqvwyzrict'
 
 let customAlphabet = (alphabet, size) => {
   return () => {

--- a/package.json
+++ b/package.json
@@ -133,14 +133,14 @@
       "name": "urlAlphabet (brotli)",
       "brotli": true,
       "import": "{ urlAlphabet }",
-      "limit": "50 B"
+      "limit": "31 B"
     },
     {
       "name": "non-secure nanoid (brotli)",
       "brotli": true,
       "import": "{ nanoid }",
       "path": "non-secure/index.js",
-      "limit": "89 B"
+      "limit": "72 B"
     },
     {
       "name": "non-secure customAlphabet (brotli)",

--- a/url-alphabet/index.js
+++ b/url-alphabet/index.js
@@ -1,6 +1,7 @@
 // This alphabet uses `A-Za-z0-9_-` symbols.
-// The order of characters is optimized for better gzip compression
+// The order of characters is optimized for better gzip and brotli compression.
+// Same as in non-secure/index.js
 let urlAlphabet =
-  'use-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abdfghjklmnopqvwxyzrict'
+  'useandom-26T198340PX75pxJACKVERYMINDBUSHWOLF_GQZbfghjklqvwyzrict'
 
 module.exports = { urlAlphabet }


### PR DESCRIPTION
A follow-up for #309: Although the Brotli size is currently not counted, probably this would be nice to have.

The "brotlied" built `non-secure nanoid` size goes down from 146 bytes to 129.

The gzip sizes are unchanged for all entries.

## How does it work

Currently only `'use`, `andom` and `rict'` are used to utilize the gzip backrefs. Other chars are just sorted alphabetically (they cannot form a gzip backref so their order is not significant for gzip).

But we also have brotli! And brotli has a built-in [the default dictionary](https://gist.github.com/klauspost/2900d5ba6f9b65d69c8e). All we need is to rerrange those "other chars" to form some substrings from the dictionary.

After a day running an ad-hoc script gave the answer for the Ultimate Question of ~Life, the Universe, and Everything~ this bizarre Scrabble game:

`-26T`
`1983`
`40px` (uppercased)
`75px`
`bush` (uppercased)
`jack` (uppercased)
`mind` (uppercased)
`very` (uppercased)
`wolf` (uppercased)

That forms a "phrase" `-26T198340PX75pxJACKVERYMINDBUSHWOLF`
<details>
  <summary>Equally good, also producing 129 bytes</summary>

```
-26T139475px80PXBINDGULFJACKVERSWHOM
-26T139475px80PXFINDJOBSMUCHVERYWALK
-26T139475PX80pxBINDGULFJACKVERSWHOM
-26T139475PX80pxFINDJOBSMUCHVERYWALK
-26T198340px75PXBINDGULFJACKVERSWHOM
-26T198340PX75pxBINDGULFJACKVERSWHOM
-26T198340PX75pxBUSHDOWNFILMJACKVERY
-26T198340PX75pxBUSHFILMJACKNDOWVERY
-26T198340PX75pxBUSHFLOWJACKMINDVERY
-26T198430px75PXBINDGULFJACKVERSWHOM
-26T198430PX75pxBINDGULFJACKVERSWHOM
```

</details>

<details>
  <summary>Honorable mention (132 bytes)</summary>

```
198640PX75pxBIRDFUCKGAVEHTMLJSON
```

</details>