### PR TITLE
Remove HTML `id` advice

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,16 +373,6 @@ const todoItems = todos.map((text, index) =>
 ```
 
 
-### HTML ID
-
-If you want to use Nano ID in the `id` prop, you must set some string prefix
-(it is invalid for the HTML ID to start with a number).
-
-```jsx
-<input id={'id' + this.id} type="text"/>
-```
-
-
 ### React Native
 
 React Native does not have built-in random generator. The following polyfill


### PR DESCRIPTION
HTML5 lifted the restrictions on `id` values, which are now essentially any character sequence: https://mathiasbynens.be/notes/html5-id-class

This was specced about 11 years ago and made with HTML ≤4.01 backwards compatibility in mind. It should be safe to no longer worry about this.