### PR TITLE
docs: remove notes about HTML id usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ Supports modern browsers, IE [with Babel], Node.js and React Native.
 * [Usage](#usage)
   * [IE](#ie)
   * [React](#react)
-  * [HTML ID](#html-id)
   * [React Native](#react-native)
   * [Rollup](#rollup)
   * [PouchDB and CouchDB](#pouchdb-and-couchdb)

--- a/README.ru.md
+++ b/README.ru.md
@@ -53,7 +53,6 @@ model.id = nanoid() //=> "V1StGXR8_Z5jdHi6B-myT"
 - [Руководство](#руководство)
   - [IE](#ie)
   - [React](#react)
-  - [HTML ID](#html-id)
   - [React Native](#react-native)
   - [Rollup](#rollup)
   - [PouchDB и CouchDB](#pouchdb-и-couchdb)
@@ -364,18 +363,6 @@ function Todos({ todos }) {
 
 Подробнее об использовании свойства `key` читайте в
 [официальной документации React](https://ru.reactjs.org/docs/lists-and-keys.html#keys).
-
-
-### HTML ID
-
-Если вы используете Nano ID для HTML-свойства `id`, то нужно в начало добавить
-какую-то строку — HTML ID не может начинаться с цифры, но Nano ID иногда может
-сгенерировать такие ID.
-
-```jsx
-<input id={'id' + this.id} type="text" />
-```
-
 
 ### React Native
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -49,7 +49,6 @@ model.id = nanoid() //=> "V1StGXR8_Z5jdHi6B-myT"
 * [用法](#用法)
   * [IE](#ie)
   * [React](#react)
-  * [HTML ID](#html-id)
   * [React Native](#react-native)
   * [Rollup](#rollup)
   * [PouchDB and CouchDB](#pouchdb-and-couchdb)
@@ -363,17 +362,6 @@ const todoItems = todos.map((text, index) =>
   </li>
 )
 ```
-
-
-### HTML ID
-
-如果你想使用 Nano ID 作为 `id` 属性，你必须设置一些字符串前缀
-(HTML ID 以数字开头是无效的)
-
-```jsx
-<input id={'id' + this.id} type="text"/>
-```
-
 
 ### React Native
 


### PR DESCRIPTION
Completely removed notes about HTML id usage. "HTML ID" anchor was broken in EN docs since this section was deleted in https://github.com/ai/nanoid/pull/316.