### PR TITLE
Add documentation in Bahasa Indonesia

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,9 @@ Read more about entropy collection in [`crypto.randomBytes`] docs.
 
 Unfortunately, you will lose Web Crypto API advantages in a browser
 if you use the asynchronous API. So, currently, in the browser, you are limited
-with either security or asynchronous behavior.
+with either security (using `nanoid`), asynchronous behavior (using `nanoid/async`), or
+non-secure behavior (using `nanoid/non-secure`) that will be explained in the next part
+of the documentation.
 
 [`crypto.randomBytes`]: https://nodejs.org/api/crypto.html#crypto_crypto_randombytes_size_callback
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img src="https://ai.github.io/nanoid/logo.svg" align="right"
      alt="Nano ID logo by Anton Lovchikov" width="180" height="94">
 
-**English** | [Русский](./README.ru.md) | [简体中文](./README.zh-CN.md)
+**English** | [Русский](./README.ru.md) | [简体中文](./README.zh-CN.md) | [Bahasa Indonesia](./README.id-ID.md)
 
 A tiny, secure, URL-friendly, unique string ID generator for JavaScript.
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -3,7 +3,7 @@
 <img src="https://ai.github.io/nanoid/logo.svg" align="right"
      alt="Логотип Nano ID от Антона Ловчикова" width="180" height="94">
 
-[English](./README.md) | **Русский** | [简体中文](./README.zh-CN.md)
+[English](./README.md) | **Русский** | [简体中文](./README.zh-CN.md) | [Bahasa Indonesia](./README.id-ID.md)
 
 Генератор уникальных ID для JavaScript — лёгкий, безопасный,
 ID можно применять в URL.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -3,7 +3,7 @@
 <img src="https://ai.github.io/nanoid/logo.svg" align="right"
      alt="Nano ID logo by Anton Lovchikov" width="180" height="94">
 
-[English](./README.md) | [Русский](./README.ru.md) | **简体中文**
+[English](./README.md) | [Русский](./README.ru.md) | **简体中文** | [Bahasa Indonesia](./README.id-ID.md)
 
 一个小巧、安全、URL友好、唯一的 JavaScript 字符串ID生成器。
 


### PR DESCRIPTION
Hi!

Thanks for making this library. It's super simple, fast, and very useful for my use-cases!

If you don't mind, I have translated and added `README.id-ID.md` for internationalization purposes (I'm from Indonesia). The documentation now has four languages: English, Russian, Chinese, and Bahasa Indonesia 🎉

By the way, I have a question about a single statement in `async` part of the documentation:

> Unfortunately, you will lose Web Crypto API advantages in a browser if you use the asynchronous API. So, currently, in the browser, you are limited with either security or asynchronous behavior.

The 'security' part here is a bit confusing for me. So, in order to remove any ambiguity, I think it's better if we rewrite this to be like:

> Unfortunately, you will lose Web Crypto API advantages in a browser if you use the asynchronous API. So, currently, in the browser, you are limited with either security (using `nanoid`), asynchronous behavior (using `nanoid/async`), or non-secure behavior (using `nanoid/non-secure`) that will be explained in the next part of the documentation.

I have not yet edited it, but what do you think about this rewrite?

Hopefully, my PR is useful. Thanks again!