### PR TITLE
doc: Fixed Typo in changelog.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Reduced `async` exports size (by Artyom Arutyunyan).
 * Moved from Jest to uvu (by Vitaly Baev).
 
-* ## 3.1.31
+## 3.1.31
 * Fixed collision vulnerability on object in `size` (by Artyom Arutyunyan).
 
 ## 3.1.30


### PR DESCRIPTION
Due to a small Typo in changelog, the version details were not fetched correctly by `renovate`.
Have fixed the same.