### PR TITLE
Switch Haskell NanoID implementation to the Community maintained one

### DIFF
--- a/README.id-ID.md
+++ b/README.id-ID.md
@@ -388,7 +388,7 @@ Nano ID telah bermigrasi ke berbagai macam bahasa. Seluruh versi dapat digunakan
 - [Deno](https://github.com/ianfabs/nanoid)
 - [Go](https://github.com/matoous/go-nanoid)
 - [Elixir](https://github.com/railsmechanic/nanoid)
-- [Haskell](https://github.com/4e6/nanoid-hs)
+- [Haskell](https://github.com/MichelBoucey/NanoID)
 - [Janet](https://sr.ht/~statianzo/janet-nanoid/)
 - [Java](https://github.com/aventrix/jnanoid)
 - [Nim](https://github.com/icyphox/nanoid.nim)

--- a/README.md
+++ b/README.md
@@ -501,7 +501,7 @@ the same ID generator on the client and server side.
 * [Deno](https://github.com/ianfabs/nanoid)
 * [Go](https://github.com/matoous/go-nanoid)
 * [Elixir](https://github.com/railsmechanic/nanoid)
-* [Haskell](https://github.com/4e6/nanoid-hs)
+* [Haskell](https://github.com/MichelBoucey/NanoID)
 * [Janet](https://sr.ht/~statianzo/janet-nanoid/)
 * [Java](https://github.com/aventrix/jnanoid)
 * [Nim](https://github.com/icyphox/nanoid.nim)

--- a/README.ru.md
+++ b/README.ru.md
@@ -485,7 +485,7 @@ Nano ID был портирован на множество языков. Это
 - [Deno](https://github.com/ianfabs/nanoid)
 - [Go](https://github.com/matoous/go-nanoid)
 - [Elixir](https://github.com/railsmechanic/nanoid)
-- [Haskell](https://github.com/4e6/nanoid-hs)
+- [Haskell](https://github.com/MichelBoucey/NanoID)
 - [Janet](https://sr.ht/~statianzo/janet-nanoid/)
 - [Java](https://github.com/aventrix/jnanoid)
 - [Nim](https://github.com/icyphox/nanoid.nim)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -472,7 +472,7 @@ Nano ID 已被移植到许多语言。 你可以使用下面这些移植，获�
 * [Deno](https://github.com/ianfabs/nanoid)
 * [Go](https://github.com/matoous/go-nanoid)
 * [Elixir](https://github.com/railsmechanic/nanoid)
-* [Haskell](https://github.com/4e6/nanoid-hs)
+* [Haskell](https://github.com/MichelBoucey/NanoID)
 * [Janet](https://sr.ht/~statianzo/janet-nanoid/)
 * [Java](https://github.com/aventrix/jnanoid)
 * [Nim](https://github.com/icyphox/nanoid.nim)


### PR DESCRIPTION
I have created and I maintain the [NanoID](https://github.com/MichelBoucey/NanoID), library and cli tool, which can be found on Haskell Community website, [Hackage](https://hackage.haskell.org/package/NanoID). That's why I suggest, with this PR, to replace the current Haskell implementation, which has a pure educational purposes, according to the author himself, by my implementation, built idiomatically the Haskell way.