### PR TITLE
Attempt to make the customAlphabet API more similar to nanoid

### DIFF
--- a/async/index.browser.js
+++ b/async/index.browser.js
@@ -1,6 +1,6 @@
 let random = async bytes => crypto.getRandomValues(new Uint8Array(bytes))
 
-let customAlphabet = (alphabet, size) => {
+let customAlphabet = (alphabet, defaultSize = 21) => {
   // First, a bitmask is necessary to generate the ID. The bitmask makes bytes
   // values closer to the alphabet size. The bitmask calculates the closest
   // `2^31 - 1` number, which exceeds the alphabet size.
@@ -24,7 +24,7 @@ let customAlphabet = (alphabet, size) => {
   // `-~i => i + 1` if i is an integer
   let step = -~((1.6 * mask * size) / alphabet.length)
 
-  return async () => {
+  return async (size = defaultSize) => {
     let id = ''
     while (true) {
       let bytes = crypto.getRandomValues(new Uint8Array(step))

--- a/async/index.d.ts
+++ b/async/index.d.ts
@@ -24,8 +24,8 @@ export function nanoid(size?: number): Promise<string>
  * will not be secure.
  *
  * @param alphabet Alphabet used to generate the ID.
- * @param size Size of the ID.
- * @returns A promise with a random string.
+ * @param size Size of the ID. The default size is 21.
+ * @returns A function that returns a promise with a random string.
  *
  * ```js
  * import { customAlphabet } from 'nanoid/async'
@@ -37,8 +37,8 @@ export function nanoid(size?: number): Promise<string>
  */
 export function customAlphabet(
   alphabet: string,
-  size: number
-): () => Promise<string>
+  defaultSize?: number
+): (size?: number) => Promise<string>
 
 /**
  * Generate an array of random bytes collected from hardware noise.

--- a/bin/nanoid.cjs
+++ b/bin/nanoid.cjs
@@ -48,9 +48,6 @@ for (let i = 2; i < process.argv.length; i++) {
 }
 
 if (alphabet) {
-  if (typeof size === 'undefined') {
-    error('You must also specify size option, when using custom alphabet')
-  }
   let customNanoid = customAlphabet(alphabet, size)
   print(customNanoid())
 } else {

--- a/non-secure/index.d.ts
+++ b/non-secure/index.d.ts
@@ -13,13 +13,13 @@
 export function nanoid(size?: number): string
 
 /**
- * Generate URL-friendly unique ID based on the custom alphabet.
+ * Generate a unique ID based on a custom alphabet.
  * This method uses the non-secure predictable random generator
  * with bigger collision probability.
  *
  * @param alphabet Alphabet used to generate the ID.
- * @param size Size of the ID.
- * @returns A random string.
+ * @param defaultSize Size of the ID. The default size is 21.
+ * @returns A function that returns a random string.
  *
  * ```js
  * import { customAlphabet } from 'nanoid/non-secure'
@@ -27,4 +27,7 @@ export function nanoid(size?: number): string
  * model.id = //=> "8ё56а"
  * ```
  */
-export function customAlphabet(alphabet: string, size: number): () => string
+export function customAlphabet(
+  alphabet: string,
+  defaultSize?: number
+): (size?: number) => string

--- a/non-secure/index.js
+++ b/non-secure/index.js
@@ -7,8 +7,8 @@
 let urlAlphabet =
   'useandom-26T198340PX75pxJACKVERYMINDBUSHWOLF_GQZbfghjklqvwyzrict'
 
-let customAlphabet = (alphabet, size) => {
-  return () => {
+let customAlphabet = (alphabet, defaultSize = 21) => {
+  return (size = defaultSize) => {
     let id = ''
     // A compact alternative for `for (var i = 0; i < step; i++)`.
     let i = size


### PR DESCRIPTION
I want to use a custom alphabet, but I find that going from `nanoid(size)` to `nanoid = customAlphabet(alphabet, size)` is a bit cumbersome.

Wouldn't it be better if the function returned by `customAlphabet` behaved exactly like `nanoid`? That way I could just change how `nanoid` is defined and the rest of my code would continue to work, since there are `nanoid` calls that generate IDs of different lengths scattered throughout the code.

So instead of:

https://github.com/ai/nanoid/blob/7528a7362ba2515d200dc60c3f00f162e7ba563e/non-secure/index.js#L10-L11

It would use:

```typescript
let customAlphabet = (alphabet) => {
  return (size = 21) => {
```

Just like the usual `nanoid` function. But since that would be a breaking change, perhaps this change would be easier to introduce?

```typescript
let customAlphabet = (alphabet, defaultSize = 21) => {
  return (size = defaultSize) => {
```

So I started making the change, but I was unsure how to change all of the files. So I figured I'll just ask here, especially since there seems to be an extreme amount of attention paid to the resulting size of the function. 🤷 

Thanks!