### PR TITLE
Update IE polyfill to fix last improve with reduce

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,12 +327,27 @@ the same result.
 ### IE
 
 If you support IE, you need to [transpile `node_modules`] by Babel
-and add `crypto` alias:
+and add `crypto` alias. Moreover, `UInt8Array` in IE actually
+is not an array and to cope with it, you have to convert it to an array
+manually:
 
 ```js
 // polyfills.js
-if (!window.crypto) {
+if (!window.crypto && window.msCrypto) {
   window.crypto = window.msCrypto
+
+  const getRandomValuesDef = window.crypto.getRandomValues
+
+  window.crypto.getRandomValues = function (array) {
+    const values = getRandomValuesDef.call(window.crypto, array)
+    const result = []
+
+    for (let i = 0; i < array.length; i++) {
+      result[i] = values[i];
+    }
+
+    return result
+  };
 }
 ```
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -335,12 +335,27 @@ const nanoid = customRandom(urlAlphabet, 10, random)
 ### IE
 
 Если вам нужна поддержка IE, потребуется включить [компиляцию `node_modules`]
-с помощью Babel и вручную убрать вендорный префикс у `crypto`.
+с помощью Babel и вручную убрать вендорный префикс у `crypto`. Кроме того,
+из-за того, что `UInt8Array` в IE является массивом, необходимо преобразовать
+метод `getRandomValues`, чтобы он возвращал массив:
 
 ```js
 // polyfills.js
-if (!window.crypto) {
+if (!window.crypto && window.msCrypto) {
   window.crypto = window.msCrypto
+
+  const getRandomValuesDef = window.crypto.getRandomValues
+
+  window.crypto.getRandomValues = function (array) {
+    const values = getRandomValuesDef.call(window.crypto, array)
+    const result = []
+
+    for (let i = 0; i < array.length; i++) {
+      result[i] = values[i];
+    }
+
+    return result
+  };
 }
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -311,8 +311,21 @@ const nanoid = customRandom(urlAlphabet, 10, random)
 
 ```js
 // polyfills.js
-if (!window.crypto) {
+if (!window.crypto && window.msCrypto) {
   window.crypto = window.msCrypto
+
+  const getRandomValuesDef = window.crypto.getRandomValues
+
+  window.crypto.getRandomValues = function (array) {
+    const values = getRandomValuesDef.call(window.crypto, array)
+    const result = []
+
+    for (let i = 0; i < array.length; i++) {
+      result[i] = values[i];
+    }
+
+    return result
+  };
 }
 ```
 


### PR DESCRIPTION
In #355 improvement with reduce was introduced. However, it relies on the fact, that `UInt8Array` is really an array, but in IE actually it's not. Today I investigated it, and it turned out, that `UInt8Array` in `msCrypto` is an object.

I found the following workaround, but I'm not sure is there any problems with it. If it's OK, I'll update Russian readme as well. 