### PR TITLE
docs: new link to Go implementation

### DIFF
--- a/README.id-ID.md
+++ b/README.id-ID.md
@@ -350,7 +350,7 @@ Nano ID telah bermigrasi ke berbagai macam bahasa. Seluruh versi dapat digunakan
 - [Crystal](https://github.com/mamantoha/nanoid.cr)
 - [Dart & Flutter](https://github.com/pd4d10/nanoid-dart)
 - [Deno](https://github.com/ianfabs/nanoid)
-- [Go](https://github.com/matoous/go-nanoid)
+- [Go](https://github.com/jaevor/go-nanoid)
 - [Elixir](https://github.com/railsmechanic/nanoid)
 - [Haskell](https://github.com/MichelBoucey/NanoID)
 - [Janet](https://sr.ht/~statianzo/janet-nanoid/)

--- a/README.md
+++ b/README.md
@@ -461,7 +461,7 @@ the same ID generator on the client and server side.
 * [Crystal](https://github.com/mamantoha/nanoid.cr)
 * [Dart & Flutter](https://github.com/pd4d10/nanoid-dart)
 * [Deno](https://github.com/ianfabs/nanoid)
-* [Go](https://github.com/matoous/go-nanoid)
+* [Go](https://github.com/jaevor/go-nanoid)
 * [Elixir](https://github.com/railsmechanic/nanoid)
 * [Haskell](https://github.com/MichelBoucey/NanoID)
 * [Janet](https://sr.ht/~statianzo/janet-nanoid/)

--- a/README.ru.md
+++ b/README.ru.md
@@ -449,7 +449,7 @@ Nano ID был портирован на множество языков. Это
 - [Crystal](https://github.com/mamantoha/nanoid.cr)
 - [Dart и Flutter](https://github.com/pd4d10/nanoid-dart)
 - [Deno](https://github.com/ianfabs/nanoid)
-- [Go](https://github.com/matoous/go-nanoid)
+- [Go](https://github.com/jaevor/go-nanoid)
 - [Elixir](https://github.com/railsmechanic/nanoid)
 - [Haskell](https://github.com/MichelBoucey/NanoID)
 - [Janet](https://sr.ht/~statianzo/janet-nanoid/)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -409,7 +409,7 @@ Nano ID 已被移植到许多语言。 你可以使用下面这些移植，获�
 * [Crystal](https://github.com/mamantoha/nanoid.cr)
 * [Dart & Flutter](https://github.com/pd4d10/nanoid-dart)
 * [Deno](https://github.com/ianfabs/nanoid)
-* [Go](https://github.com/matoous/go-nanoid)
+* [Go](https://github.com/jaevor/go-nanoid)
 * [Elixir](https://github.com/railsmechanic/nanoid)
 * [Haskell](https://github.com/MichelBoucey/NanoID)
 * [Janet](https://sr.ht/~statianzo/janet-nanoid/)


### PR DESCRIPTION
I created a newer and improved Go implementation of nanoid ([link](https://github.com/jaevor/go-nanoid)) and I wanted to update the links in the reference repo 🙂.