### PR TITLE
Add small section on using built in useId-hook in newer React versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,6 @@ const todoItems = todos.map((text, index) =>
 
 In case you just need random IDs to link elements like labels and input fields together, [useId](https://reactjs.org/docs/hooks-reference.html#useid) is recommended. That hook was added in React 18.
 
-
 ### React Native
 
 React Native does not have built-in random generator. The following polyfill

--- a/README.md
+++ b/README.md
@@ -357,6 +357,8 @@ const todoItems = todos.map((text, index) =>
 )
 ```
 
+In case you just need random IDs to link elements like labels and input fields together, [useId](https://reactjs.org/docs/hooks-reference.html#useid) is recommended. That hook was added in React 18.
+
 
 ### React Native
 


### PR DESCRIPTION
Hello, it might be helpful to some users to mention the new `useId` hook from React 18 as a simple alternative to nanoid for html attributes.

Cheers