### PR TITLE
"returns a function that"

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ const id = nanoid() //=> "Uakgb_J5m9g-0JDMbcJqLJ"
 
 ### Custom Alphabet or Size
 
-`customAlphabet` allows you to create `nanoid` with your own alphabet
+`customAlphabet` returns a function that allows you to create `nanoid` with your own alphabet
 and ID size.
 
 ```js


### PR DESCRIPTION
Simple README.md change to draw attention to the fact that customAlphabet returns a function.