### PR TITLE
docs: update Go library to atoous/go-nanoid

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ the same ID generator on the client and server side.
 * [Crystal](https://github.com/mamantoha/nanoid.cr)
 * [Dart & Flutter](https://github.com/pd4d10/nanoid-dart)
 * [Deno](https://github.com/ianfabs/nanoid)
-* [Go](https://github.com/jaevor/go-nanoid)
+* [Go](https://github.com/matoous/go-nanoid)
 * [Elixir](https://github.com/railsmechanic/nanoid)
 * [Haskell](https://github.com/MichelBoucey/NanoID)
 * [Janet](https://sr.ht/~statianzo/janet-nanoid/)


### PR DESCRIPTION
https://github.com/jaevor/go-nanoid license was changed to GPL. Recommend an alternate implementation.