### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ It has a similar number of random bits in the ID
 > For there to be a one in a billion chance of duplication,
 > 103 trillion version 4 IDs must be generated.
 
-There are three main differences between Nano ID and UUID v4:
+There are two main differences between Nano ID and UUID v4:
 
 1. Nano ID uses a bigger alphabet, so a similar number of random bits
    are packed in just 21 symbols instead of 36.


### PR DESCRIPTION
Minor correction in differences between Nano ID & UUID v4.

It used to list *three* differences which included Nano ID being 2x faster than UUID v4, but this difference was removed after a comprehensive benchmark was added showing UUID to be faster now.

Nano ID still generates millions of ids per second so I don't see it being slower now being particularly note-worthy, especially given the benchmark comparison is displayed below.