### PR TITLE
fix(node): use webcrypto export from `node:crypto`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import crypto from 'node:crypto'
+import { webcrypto as crypto } from 'node:crypto'
 
 import { urlAlphabet } from './url-alphabet/index.js'
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url"
   ],
   "scripts": {
-    "clean": "rm -R coverage",
+    "clean": "rm -rf coverage",
     "start": "vite test/demo/ --open",
     "unit": "uvu . .test.js$",
     "test:coverage": "c8 pnpm unit",


### PR DESCRIPTION
Using `crypto.webcrypto.getRandomValues()` is recommended instead of directly using the aliased version from `crypto.getRandomValues()` as the latter is not meant to be compatible with the WebCrypto spec and is non-standard. 

There was earlier discussion on this in the node repo - https://github.com/nodejs/node/pull/41779, https://github.com/nodejs/node/pull/41782,  https://github.com/nodejs/node/pull/41760

This is breaking some downstream tools as well that are bundling / down-compiling nanoid (although that's not much of an nanoid issue).

PS: updating the `clean` script as well. Running `test` was failing for new contributors who don't already have a coverage directory.