### PR TITLE
Update java library

### DIFF
--- a/README.id-ID.md
+++ b/README.id-ID.md
@@ -318,7 +318,7 @@ Nano ID telah bermigrasi ke berbagai macam bahasa. Seluruh versi dapat digunakan
 - [Haskell](https://github.com/MichelBoucey/NanoID)
 - [Haxe](https://github.com/flashultra/uuid)
 - [Janet](https://sr.ht/~statianzo/janet-nanoid/)
-- [Java](https://github.com/aventrix/jnanoid)
+- [Java](https://github.com/Soundicly/jnanoid-enhanced)
 - [Kotlin](https://github.com/viascom/nanoid-kotlin)
 - [MySQL/MariaDB](https://github.com/viascom/nanoid-mysql-mariadb)
 - [Nim](https://github.com/icyphox/nanoid.nim)

--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ the same ID generator on the client and server side.
 * [Haskell](https://github.com/MichelBoucey/NanoID)
 * [Haxe](https://github.com/flashultra/uuid)
 * [Janet](https://sr.ht/~statianzo/janet-nanoid/)
-* [Java](https://github.com/aventrix/jnanoid)
+* [Java](https://github.com/Soundicly/jnanoid-enhanced)
 * [Kotlin](https://github.com/viascom/nanoid-kotlin)
 * [MySQL/MariaDB](https://github.com/viascom/nanoid-mysql-mariadb)
 * [Nim](https://github.com/icyphox/nanoid.nim)

--- a/README.ru.md
+++ b/README.ru.md
@@ -394,7 +394,7 @@ Nano ID был портирован на множество языков. Это
 - [Haskell](https://github.com/MichelBoucey/NanoID)
 - [Haxe](https://github.com/flashultra/uuid)
 - [Janet](https://sr.ht/~statianzo/janet-nanoid/)
-- [Java](https://github.com/aventrix/jnanoid)
+- [Java](https://github.com/Soundicly/jnanoid-enhanced)
 - [Kotlin](https://github.com/viascom/nanoid-kotlin)
 - [MySQL/MariaDB](https://github.com/viascom/nanoid-mysql-mariadb)
 - [Nim](https://github.com/icyphox/nanoid.nim)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -386,7 +386,7 @@ Nano ID 已被移植到许多语言。 你可以使用下面这些移植，获�
 * [Haskell](https://github.com/MichelBoucey/NanoID)
 * [Haxe](https://github.com/flashultra/uuid)
 * [Janet](https://sr.ht/~statianzo/janet-nanoid/)
-* [Java](https://github.com/aventrix/jnanoid)
+* [Java](https://github.com/Soundicly/jnanoid-enhanced)
 * [Kotlin](https://github.com/viascom/nanoid-kotlin)
 * [MySQL/MariaDB](https://github.com/viascom/nanoid-mysql-mariadb)
 * [Nim](https://github.com/icyphox/nanoid.nim)


### PR DESCRIPTION
Hey,
A while back I forked the original Java nanoid library (jnanoid), since optimizations and improvements could be made:

- Security Issue: Remote code execution could be ran.
- Random Security: Java's more secure Random wasn't being used.
- Better Unit Testing
- More useful methods

In the readme the recommended Java Library is still pointing to the discontinued one. I've updated it.