### PR TITLE
chore(readme): Add python fastnanoid

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,8 +422,9 @@ the same ID generator on the client and server side.
 * [OCaml](https://github.com/routineco/ocaml-nanoid)
 * [Perl](https://github.com/tkzwtks/Nanoid-perl)
 * [PHP](https://github.com/hidehalo/nanoid-php)
-* [Python](https://github.com/puyuan/py-nanoid)
+* Python [native](https://github.com/puyuan/py-nanoid) implementation
   with [dictionaries](https://pypi.org/project/nanoid-dictionary)
+  and [fast](https://github.com/oliverlambson/fastnanoid) implementation (written in Rust)
 * Postgres [Extension](https://github.com/spa5k/uids-postgres)
   and [Native Function](https://github.com/viascom/nanoid-postgres)
 * [R](https://github.com/hrbrmstr/nanoid) (with dictionaries)


### PR DESCRIPTION
The original python implementation ([py-nanoid](https://github.com/puyuan/py-nanoid)) is unmaintained by the author and no-one else is able to merge contributions. (see: [2 year old PRs going un-acknowledged](https://github.com/puyuan/py-nanoid/pull/24#issuecomment-1019324237))

A new nanoid python library has been written in Rust ([fastnanoid](https://github.com/oliverlambson/fastnanoid)) and is 2.7x faster than the native python implementation.