### PR TITLE
Fix CJS compatibility

### DIFF
--- a/index.browser.js
+++ b/index.browser.js
@@ -61,4 +61,4 @@ export let nanoid = (size = 21) => {
   return id
 }
 
-export default { random, customRandom, customAlphabet, nanoid }
+export default { customAlphabet, customRandom, nanoid, random }

--- a/index.browser.js
+++ b/index.browser.js
@@ -60,3 +60,5 @@ export let nanoid = (size = 21) => {
   }
   return id
 }
+
+export default { random, customRandom, customAlphabet, nanoid }

--- a/index.d.ts
+++ b/index.d.ts
@@ -89,3 +89,5 @@ export const urlAlphabet: string
  * @returns An array of random bytes.
  */
 export function random(bytes: number): Uint8Array
+
+export default { customAlphabet, customRandom, nanoid, random }

--- a/index.js
+++ b/index.js
@@ -85,4 +85,4 @@ export function nanoid(size = 21) {
   return id
 }
 
-export default { random, customRandom, customAlphabet, nanoid }
+export default { customAlphabet, customRandom, nanoid, random }

--- a/index.js
+++ b/index.js
@@ -84,3 +84,5 @@ export function nanoid(size = 21) {
   }
   return id
 }
+
+export default { random, customRandom, customAlphabet, nanoid }

--- a/non-secure/index.d.ts
+++ b/non-secure/index.d.ts
@@ -31,3 +31,5 @@ export function customAlphabet(
   alphabet: string,
   defaultSize?: number
 ): (size?: number) => string
+
+export default { customAlphabet, nanoid }

--- a/non-secure/index.js
+++ b/non-secure/index.js
@@ -30,3 +30,5 @@ export let nanoid = (size = 21) => {
   }
   return id
 }
+
+export default { customAlphabet, nanoid }

--- a/url-alphabet/index.js
+++ b/url-alphabet/index.js
@@ -3,3 +3,5 @@
 // Same as in non-secure/index.js
 export const urlAlphabet =
   'useandom-26T198340PX75pxJACKVERYMINDBUSHWOLF_GQZbfghjklqvwyzrict'
+
+export default { urlAlphabet }


### PR DESCRIPTION
# Proposed Changes

Ensure compatibility with some CDNs & bundlers on some CJS libraries.

jsDelivr translates `const { nanoid } = require('nanoid')` directly into `import e from 'nanoid/+esm'; const { nanoid } = e`, which is problematic and causes some libraries fail to load.

Here is an example using `postcss`:

```js
await import('https://cdn.jsdelivr.net/npm/postcss@8.4.41/+esm')
```

# Additional Information

It is suggested to squash merge this PR.