### PR TITLE
use `Math.log2` instead of `Math.log / Math.LN2`

### DIFF
--- a/index.browser.js
+++ b/index.browser.js
@@ -13,7 +13,7 @@ export let customRandom = (alphabet, defaultSize, getRandom) => {
   // `2^31 - 1` number, which exceeds the alphabet size.
   // For example, the bitmask for the alphabet size 30 is 31 (00011111).
   // `Math.clz32` is not used, because it is not available in browsers.
-  let mask = (2 << (Math.log(alphabet.length - 1) / Math.LN2)) - 1
+  let mask = (2 << Math.log2(alphabet.length - 1)) - 1
   // Though, the bitmask solution is not perfect since the bytes exceeding
   // the alphabet size are refused. Therefore, to reliably generate the ID,
   // the random bytes redundancy has to be satisfied.


### PR DESCRIPTION
I have noticed that this line in `index.browser.js`:

```js
let mask = (2 << (Math.log(alphabet.length - 1) / Math.LN2)) - 1
```

uses `Math.log() / Math.LN2` to get the `log2`,

while it can be made shorter by using widely available `Math.log2` method:

```js
let mask = (2 << Math.log2(alphabet.length - 1)) - 1
```

How did I notice it?

Because there's an eslint rule that recommends that: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-modern-math-apis.md#prefer-mathlog2x-over

`Math.log2` seems to be widely available in the Browsers and I see no reason why it shouldn't be used.