### PR TITLE
Fix pool pollution, infinite loop

### DIFF
--- a/async/index.browser.js
+++ b/async/index.browser.js
@@ -29,7 +29,7 @@ let customAlphabet = (alphabet, defaultSize = 21) => {
     while (true) {
       let bytes = crypto.getRandomValues(new Uint8Array(step))
       // A compact alternative for `for (var i = 0; i < step; i++)`.
-      let i = step
+      let i = step | 0
       while (i--) {
         // Adding `|| ''` refuses a random byte that exceeds the alphabet size.
         id += alphabet[bytes[i] & mask] || ''
@@ -41,7 +41,7 @@ let customAlphabet = (alphabet, defaultSize = 21) => {
 
 let nanoid = async (size = 21) => {
   let id = ''
-  let bytes = crypto.getRandomValues(new Uint8Array(size))
+  let bytes = crypto.getRandomValues(new Uint8Array((size |= 0)))
 
   // A compact alternative for `for (var i = 0; i < step; i++)`.
   while (size--) {

--- a/async/index.js
+++ b/async/index.js
@@ -45,7 +45,7 @@ let customAlphabet = (alphabet, defaultSize = 21) => {
       while (i--) {
         // Adding `|| ''` refuses a random byte that exceeds the alphabet size.
         id += alphabet[bytes[i] & mask] || ''
-        if (id.length === size) return id
+        if (id.length >= size) return id
       }
       return tick(id, size)
     })
@@ -54,7 +54,7 @@ let customAlphabet = (alphabet, defaultSize = 21) => {
 }
 
 let nanoid = (size = 21) =>
-  random(size).then(bytes => {
+  random((size |= 0)).then(bytes => {
     let id = ''
     // A compact alternative for `for (var i = 0; i < step; i++)`.
     while (size--) {

--- a/async/index.native.js
+++ b/async/index.native.js
@@ -31,7 +31,7 @@ let customAlphabet = (alphabet, defaultSize = 21) => {
       while (i--) {
         // Adding `|| ''` refuses a random byte that exceeds the alphabet size.
         id += alphabet[bytes[i] & mask] || ''
-        if (id.length === size) return id
+        if (id.length >= size) return id
       }
       return tick(id, size)
     })
@@ -40,7 +40,7 @@ let customAlphabet = (alphabet, defaultSize = 21) => {
 }
 
 let nanoid = (size = 21) =>
-  random(size).then(bytes => {
+  random((size |= 0)).then(bytes => {
     let id = ''
     // A compact alternative for `for (var i = 0; i < step; i++)`.
     while (size--) {

--- a/index.browser.js
+++ b/index.browser.js
@@ -34,7 +34,7 @@ let customRandom = (alphabet, defaultSize, getRandom) => {
     while (true) {
       let bytes = getRandom(step)
       // A compact alternative for `for (var i = 0; i < step; i++)`.
-      let j = step
+      let j = step | 0
       while (j--) {
         // Adding `|| ''` refuses a random byte that exceeds the alphabet size.
         id += alphabet[bytes[j] & mask] || ''

--- a/index.js
+++ b/index.js
@@ -23,8 +23,8 @@ let fillPool = bytes => {
 }
 
 let random = bytes => {
-  // `-=` convert `bytes` to number to prevent `valueOf` abusing
-  fillPool((bytes -= 0))
+  // `|=` convert `bytes` to number to prevent `valueOf` abusing and pool pollution
+  fillPool((bytes |= 0))
   return pool.subarray(poolOffset - bytes, poolOffset)
 }
 
@@ -67,8 +67,8 @@ let customAlphabet = (alphabet, size = 21) =>
   customRandom(alphabet, size, random)
 
 let nanoid = (size = 21) => {
-  // `-=` convert `size` to number to prevent `valueOf` abusing
-  fillPool((size -= 0))
+  // `|=` convert `size` to number to prevent `valueOf` abusing and pool pollution
+  fillPool((size |= 0))
   let id = ''
   // We are reading directly from the random pool to avoid creating new array
   for (let i = poolOffset - size; i < poolOffset; i++) {

--- a/non-secure/index.js
+++ b/non-secure/index.js
@@ -11,7 +11,7 @@ let customAlphabet = (alphabet, defaultSize = 21) => {
   return (size = defaultSize) => {
     let id = ''
     // A compact alternative for `for (var i = 0; i < step; i++)`.
-    let i = size
+    let i = size | 0
     while (i--) {
       // `| 0` is more compact and faster than `Math.floor()`.
       id += alphabet[(Math.random() * alphabet.length) | 0]
@@ -23,7 +23,7 @@ let customAlphabet = (alphabet, defaultSize = 21) => {
 let nanoid = (size = 21) => {
   let id = ''
   // A compact alternative for `for (var i = 0; i < step; i++)`.
-  let i = size
+  let i = size | 0
   while (i--) {
     // `| 0` is more compact and faster than `Math.floor()`.
     id += urlAlphabet[(Math.random() * 64) | 0]

--- a/test/async.test.js
+++ b/test/async.test.js
@@ -1,6 +1,6 @@
 let { suite } = require('uvu')
 let { spy } = require('nanospy')
-let { is, match, ok } = require('uvu/assert')
+let { is, match, ok, not } = require('uvu/assert')
 let crypto = require('crypto')
 
 global.crypto = {
@@ -53,6 +53,13 @@ for (let type of ['node', 'browser']) {
         }
       })
     )
+  })
+
+  nanoidSuite('avoids pool pollution, infinite loop', async () => {
+    await nanoid(2.1)
+    const second = await nanoid()
+    const third = await nanoid()
+    not.equal(second, third)
   })
 
   nanoidSuite('changes ID length', async () => {

--- a/test/async.test.js
+++ b/test/async.test.js
@@ -57,8 +57,8 @@ for (let type of ['node', 'browser']) {
 
   nanoidSuite('avoids pool pollution, infinite loop', async () => {
     await nanoid(2.1)
-    const second = await nanoid()
-    const third = await nanoid()
+    let second = await nanoid()
+    let third = await nanoid()
     not.equal(second, third)
   })
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -36,8 +36,8 @@ for (let type of ['node', 'browser']) {
 
   test(`${type} / nanoid / avoids pool pollution, infinite loop`, () => {
     nanoid(2.1)
-    const second = nanoid()
-    const third = nanoid()
+    let second = nanoid()
+    let third = nanoid()
     not.equal(second, third)
   })
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,5 +1,5 @@
 let { test } = require('uvu')
-let { is, ok, equal, match } = require('uvu/assert')
+let { is, ok, equal, match, not } = require('uvu/assert')
 
 let browser = require('../index.browser.js')
 let node = require('../index.js')
@@ -32,6 +32,13 @@ for (let type of ['node', 'browser']) {
         match(urlAlphabet, new RegExp(char, "g"))
       }
     }
+  })
+
+  test(`${type} / nanoid / avoids pool pollution, infinite loop`, () => {
+    nanoid(2.1)
+    const second = nanoid()
+    const third = nanoid()
+    not.equal(second, third)
   })
 
   test(`${type} / nanoid / changes ID length`, () => {

--- a/test/non-secure.test.js
+++ b/test/non-secure.test.js
@@ -1,5 +1,5 @@
 let { test } = require('uvu')
-let { is, match, ok } = require('uvu/assert')
+let { is, match, ok, not } = require('uvu/assert')
 
 let { nanoid, customAlphabet } = require('../non-secure')
 let { urlAlphabet } = require('..')
@@ -56,6 +56,13 @@ test('nanoid / has flat distribution', () => {
   ok(max - min <= 0.05)
 })
 
+test('nanoid / avoids pool pollution, infinite loop', () => {
+  nanoid(2.1)
+  const second = nanoid()
+  const third = nanoid()
+  not.equal(second, third)
+})
+
 test('customAlphabet / has options', () => {
   let nanoidA = customAlphabet('a', 5)
   is(nanoidA(), 'aaaaa')
@@ -86,6 +93,15 @@ test('customAlphabet / has flat distribution', () => {
     if (distribution < min) min = distribution
   }
   ok(max - min <= 0.05)
+})
+
+test('customAlphabet / avoids pool pollution, infinite loop', () => {
+  let ALPHABET = 'abcdefghijklmnopqrstuvwxyz'
+  let nanoid2 = customAlphabet(ALPHABET)
+  nanoid2(2.1)
+  const second = nanoid2()
+  const third = nanoid2()
+  not.equal(second, third)
 })
 
 test.run()

--- a/test/non-secure.test.js
+++ b/test/non-secure.test.js
@@ -58,8 +58,8 @@ test('nanoid / has flat distribution', () => {
 
 test('nanoid / avoids pool pollution, infinite loop', () => {
   nanoid(2.1)
-  const second = nanoid()
-  const third = nanoid()
+  let second = nanoid()
+  let third = nanoid()
   not.equal(second, third)
 })
 
@@ -99,8 +99,8 @@ test('customAlphabet / avoids pool pollution, infinite loop', () => {
   let ALPHABET = 'abcdefghijklmnopqrstuvwxyz'
   let nanoid2 = customAlphabet(ALPHABET)
   nanoid2(2.1)
-  const second = nanoid2()
-  const third = nanoid2()
+  let second = nanoid2()
+  let third = nanoid2()
   not.equal(second, third)
 })
 

--- a/test/react-native-polyfill.test.js
+++ b/test/react-native-polyfill.test.js
@@ -30,8 +30,8 @@ test('works with polyfill', () => {
 test('nanoid / avoids pool pollution, infinite loop', () => {
   let { nanoid } = require('../index.browser')
   nanoid(2.1)
-  const second = nanoid()
-  const third = nanoid()
+  let second = nanoid()
+  let third = nanoid()
   not.equal(second, third)
 })
 

--- a/test/react-native-polyfill.test.js
+++ b/test/react-native-polyfill.test.js
@@ -1,5 +1,5 @@
 let { test } = require('uvu')
-let { is } = require('uvu/assert')
+let { is, not } = require('uvu/assert')
 
 test.before(() => {
   global.navigator = {
@@ -25,6 +25,14 @@ test('works with polyfill', () => {
   let { nanoid } = require('../index.browser')
 
   is(typeof nanoid(), 'string')
+})
+
+test('nanoid / avoids pool pollution, infinite loop', () => {
+  let { nanoid } = require('../index.browser')
+  nanoid(2.1)
+  const second = nanoid()
+  const third = nanoid()
+  not.equal(second, third)
 })
 
 test.run()


### PR DESCRIPTION
When nanoid is called with a fractional value, there were a number of undesirable effects:
- in browser and non-secure, the code infinite loops on `while (size--)`
- in node, the value of poolOffset becomes fractional, causing calls to nanoid to return zeroes until the pool is next filled: when `i` is initialized to `poolOffset`, `pool[i] & 63` -> `undefined & 63` -> `0`
- if the first call in node is a fractional argument, the initial buffer allocation fails with an error

I chose `|0` to cast to a signed integer primarily because that has a slightly better outcome in the third case above: if the first call is negative (e.g. `nanoid(-1)`) then Node will throw an error for an invalid Buffer size, rather than attempting to allocate a buffer of size `2**32-1`. It's also more compact than `>>>0`, which would be necessary to cast to an unsigned integer. I don't _think_ there is a use case for generating ids longer than `2**31-1` :)

The browser code is structured in such a way that casting `size` in `customRandom` succinctly isn't readily feasible. I chose to cast it at the line `let j = step | 0` since casting defaultSize would not fix the infinite loop in all cases, and the other use of defaultSize is to define the step length which is already shown to be fractional and gets cast to an integer with `~` anyway.

As for the `nanoid` function, `new Uint8Array(size)` ignores the fractional part, and `size` doesn't get used further - the function instead calls reduce over the typed array.

In the Node/native async customAlphabet variant, I chose to convert the `id.length === size` check to `id.length >= size`, which handles the fractional case and avoids the infinite loop; `size` is not used for anything else there.