### PR TITLE
Add a C port to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ bccbcabaabaccab
 Nano ID was ported to many languages. You can use these ports to have
 the same ID generator on the client and server side.
 
+* [C](https://github.com/lukateras/nanoid.h)
 * [C#](https://github.com/codeyu/nanoid-net)
 * [C++](https://github.com/mcmikecreations/nanoid_cpp)
 * [Clojure and ClojureScript](https://github.com/zelark/nano-id)


### PR DESCRIPTION
Andrey!

I've ported Nano ID to C. See: <https://github.com/lukateras/nanoid.h>

The core [`nanoid.h`](https://github.com/lukateras/nanoid.h/blob/aab8a10e015c24a3c4682fda22eeff5a43a9544a/nanoid.h) is, much like `nanoid.js`, made as compact as possible and currently sits at 270 bytes. There's more cruft in C, types and headers and allocations and all, so it's a bit bulkier than the original, but still retains the same spirit (:

The README likewise follows the same design and structure as yours. There are also man pages, a command line interface, and a build system; all batteries included.

Передаю привет из одной испаноязычной страны в другую ^^