### PR TITLE
Add instructions for dynamic import in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,10 @@ Nano ID 5 can be used with CommonJS in one of the following ways:
 
 - For Node.js 16 or newer you can dynamically import Nano ID as follows:
   ```js
-  const { nanoid } = await import('nanoid');
-  const id = nanoid() // => "V1StGXR8_Z5jdHi6B-myT"
+  module.exports.createID = async () => {
+    const { nanoid } = await import('nanoid');
+    const id = nanoid() // => "V1StGXR8_Z5jdHi6B-myT"
+  }
   ```
   _Note: In CommonJS, `await` cannot be used at the top level. If you need to handle a promise at the top level, use `.then()` instead._
 

--- a/README.md
+++ b/README.md
@@ -132,15 +132,8 @@ Test configuration: Framework 13 7840U, Fedora 39, Node.js 21.6.
 npm install nanoid
 ```
 
+### ESM
 Nano ID 5 works with ESM projects (with `import`) in tests or Node.js scripts.
-For CommonJS `require()` you need to use latest Node.js 22.12
-(works out-of-the-box) or Node.js 20 (with `--experimental-require-module`):
-
-For Node.js 18 you can either import the package dynamically or you can use Nano ID 3.x (we still support it):
-
-```bash
-npm install nanoid@3
-```
 
 For quick hacks, you can load Nano ID from CDN. Though, it is not recommended
 to be used in production because of the lower loading performance.
@@ -149,6 +142,22 @@ to be used in production because of the lower loading performance.
 import { nanoid } from 'https://cdn.jsdelivr.net/npm/nanoid/nanoid.js'
 ```
 
+### CommonJS
+Nano ID 5 can be used with CommonJS in one of the following ways:
+
+- You can use `require()` to import Nano ID. You need to use latest Node.js 22.12 (works out-of-the-box) or Node.js 20 (with `--experimental-require-module`)
+
+- For Node.js 16 or newer you can dynamically import Nano ID as follows:
+  ```js
+  const { nanoid } = await import('nanoid');
+  const id = nanoid() // => "V1StGXR8_Z5jdHi6B-myT"
+  ```
+  _Note: In CommonJS, `await` cannot be used at the top level. If you need to handle a promise at the top level, use `.then()` instead._
+
+- You can use Nano ID 3.x (we still support it):
+  ```bash
+  npm install nanoid@3
+  ```
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Nano ID 5 works with ESM projects (with `import`) in tests or Node.js scripts.
 For CommonJS `require()` you need to use latest Node.js 22.12
 (works out-of-the-box) or Node.js 20 (with `--experimental-require-module`):
 
-For Node.js 18 you can use Nano ID 3.x (we still support it):
+For Node.js 18 you can either import the package dynamically or you can use Nano ID 3.x (we still support it):
 
 ```bash
 npm install nanoid@3

--- a/README.md
+++ b/README.md
@@ -149,12 +149,13 @@ Nano ID 5 can be used with CommonJS in one of the following ways:
 
 - For Node.js 16 or newer you can dynamically import Nano ID as follows:
   ```js
+  let nanoid;
+  
   module.exports.createID = async () => {
-    const { nanoid } = await import('nanoid');
+    if (!nanoid) ({ nanoid } = await import('nanoid'));
     const id = nanoid() // => "V1StGXR8_Z5jdHi6B-myT"
   }
   ```
-  _Note: In CommonJS, `await` cannot be used at the top level. If you need to handle a promise at the top level, use `.then()` instead._
 
 - You can use Nano ID 3.x (we still support it):
   ```bash


### PR DESCRIPTION
## Pull Request Overview

I edited the README to include the option to dynamically import the latest nanoid version even when an earlier version of Node is being used.

## Pull Request Details

When working on a specific project, I was in a situation where I was using Node JS 20.11.0 and commonJS. Without going into details, we could neither switch over to ESM nor could we upgrade to Node JS 20.12.0. The only solution that worked for me was importing the module dynamically as follows:

```js
module.exports.create = async () => {
  const { customAlphabet } = await import('nanoid');
  const nanoid = customAlphabet(alphanumeric, 10);

  // Remaining code
};
```
This helped solve my issue and I would like to help other developers who might be facing a similar issue.

Thank you for creating this great package!

