### PR TITLE
Change customRandom signature to accept optional size

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -79,7 +79,7 @@ export function customRandom<Type extends string>(
   alphabet: string,
   size: number,
   random: (bytes: number) => Uint8Array
-): () => Type
+): (size?: number) => Type
 
 /**
  * URL safe symbols.


### PR DESCRIPTION
Type signature of customRandom() does not reflect the fact that [the returned generator accepts an optional size](https://github.com/ai/nanoid/blob/9d574d2c9706f5cf82e2a043450c62664ea1fcf1/index.js#L53)

This fixes it.