### PR TITLE
[misc] Replace Swift Implementation in README

### DIFF
--- a/README.id-ID.md
+++ b/README.id-ID.md
@@ -342,7 +342,7 @@ Nano ID telah bermigrasi ke berbagai macam bahasa. Seluruh versi dapat digunakan
 - [R](https://github.com/hrbrmstr/nanoid) (with dictionaries)
 - [Ruby](https://github.com/radeno/nanoid.rb)
 - [Rust](https://github.com/nikolay-govorov/nanoid)
-- [Swift](https://github.com/antiflasher/NanoID)
+- [Swift](https://github.com/ShivaHuang/swift-nanoid)
 - [Unison](https://share.unison-lang.org/latest/namespaces/hojberg/nanoid)
 - [V](https://github.com/invipal/nanoid)
 - [Zig](https://github.com/SasLuca/zig-nanoid)

--- a/README.ja.md
+++ b/README.ja.md
@@ -457,7 +457,7 @@ Nano IDは多くの言語に移植されています。これらのポートを�
 * [R](https://github.com/hrbrmstr/nanoid)（辞書付き）
 * [Ruby](https://github.com/radeno/nanoid.rb)
 * [Rust](https://github.com/nikolay-govorov/nanoid)
-* [Swift](https://github.com/antiflasher/NanoID)
+* [Swift](https://github.com/ShivaHuang/swift-nanoid)
 * [Unison](https://share.unison-lang.org/latest/namespaces/hojberg/nanoid)
 * [V](https://github.com/invipal/nanoid)
 * [Zig](https://github.com/SasLuca/zig-nanoid)

--- a/README.ko.md
+++ b/README.ko.md
@@ -461,7 +461,7 @@ Nano ID는 다양한 언어로 포팅되었습니다. 클라이언트/서버에 
 * [R](https://github.com/hrbrmstr/nanoid) (with dictionaries)
 * [Ruby](https://github.com/radeno/nanoid.rb)
 * [Rust](https://github.com/nikolay-govorov/nanoid)
-* [Swift](https://github.com/antiflasher/NanoID)
+* [Swift](https://github.com/ShivaHuang/swift-nanoid)
 * [Unison](https://share.unison-lang.org/latest/namespaces/hojberg/nanoid)
 * [V](https://github.com/invipal/nanoid)
 * [Zig](https://github.com/SasLuca/zig-nanoid)

--- a/README.md
+++ b/README.md
@@ -477,7 +477,7 @@ the same ID generator on the client and server side.
 * [R](https://github.com/hrbrmstr/nanoid) (with dictionaries)
 * [Ruby](https://github.com/radeno/nanoid.rb)
 * [Rust](https://github.com/nikolay-govorov/nanoid)
-* [Swift](https://github.com/antiflasher/NanoID)
+* [Swift](https://github.com/ShivaHuang/swift-nanoid)
 * [Unison](https://share.unison-lang.org/latest/namespaces/hojberg/nanoid)
 * [V](https://github.com/invipal/nanoid)
 * [Zig](https://github.com/SasLuca/zig-nanoid)

--- a/README.ru.md
+++ b/README.ru.md
@@ -455,7 +455,7 @@ Nano ID был портирован на множество языков. Это
 - [R](https://github.com/hrbrmstr/nanoid) (со словарями)
 - [Ruby](https://github.com/radeno/nanoid.rb)
 - [Rust](https://github.com/nikolay-govorov/nanoid)
-- [Swift](https://github.com/antiflasher/NanoID)
+- [Swift](https://github.com/ShivaHuang/swift-nanoid)
 - [Unison](https://share.unison-lang.org/latest/namespaces/hojberg/nanoid)
 - [V](https://github.com/invipal/nanoid)
 - [Zig](https://github.com/SasLuca/zig-nanoid)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -406,7 +406,7 @@ Nano ID 已被移植到许多语言。 你可以使用下面这些移植，获�
 * [R](https://github.com/hrbrmstr/nanoid) (with dictionaries)
 * [Ruby](https://github.com/radeno/nanoid.rb)
 * [Rust](https://github.com/nikolay-govorov/nanoid)
-* [Swift](https://github.com/antiflasher/NanoID)
+* [Swift](https://github.com/ShivaHuang/swift-nanoid)
 * [Unison](https://share.unison-lang.org/latest/namespaces/hojberg/nanoid)
 * [V](https://github.com/invipal/nanoid)
 * [Zig](https://github.com/SasLuca/zig-nanoid)


### PR DESCRIPTION
As discussed in #552, replacing the existing Swift link with a more actively maintained implementation.

Changes: antiflasher/NanoID → ShivaHuang/swift-nanoid