### PR TITLE
Fix 0-size browser customAlphabet

### DIFF
--- a/index.browser.js
+++ b/index.browser.js
@@ -34,6 +34,7 @@ export let customRandom = (alphabet, defaultSize, getRandom) => {
   let step = -~((1.6 * mask * defaultSize) / alphabet.length)
 
   return (size = defaultSize) => {
+    if (!size) return ''
     let id = ''
     while (true) {
       let bytes = getRandom(step)

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     {
       "name": "customAlphabet",
       "import": "{ customAlphabet }",
-      "limit": "165 B"
+      "limit": "173 B"
     },
     {
       "name": "urlAlphabet",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -138,6 +138,11 @@ for (let type of ['node', 'browser']) {
       equal(nanoidA(10), 'aaaaaaaaaa')
     })
 
+    test(`${type} / customAlphabet / is ready for 0 size`, () => {
+      equal(customAlphabet('abc')(0), '')
+      equal(customAlphabet('abc', 0)(0), '')
+    })
+
     test(`${type} / customAlphabet / avoids pool pollution, infinite loop`, () => {
       let ALPHABET = 'abcdefghijklmnopqrstuvwxyz'
       let nanoid2 = customAlphabet(ALPHABET)
@@ -160,6 +165,11 @@ for (let type of ['node', 'browser']) {
       let nanoid18 = customRandom('abcde', 18, fakeRandom)
       equal(nanoid4(), 'adca')
       equal(nanoid18(), 'cbadcbadcbadcbadcc')
+    })
+
+    test(`${type} / customRandom / is ready for 0 size`, () => {
+      let nanoid0 = customRandom('abc', 5, size => new Uint8Array(size))
+      equal(nanoid0(0), '')
     })
 
     test(`${type} / urlAlphabet / is string`, () => {


### PR DESCRIPTION
## What

Fix the browser `customRandom()` path so `size = 0` returns an empty string. Since `customAlphabet()` is built on top of `customRandom()`, this also fixes `customAlphabet(...)(0)` in the browser build.

## Why

The Node implementation already handles zero-size requests, but the browser implementation did not. It still entered the generation loop and appended a character before checking the target length, so calls like `customAlphabet('abc')(0)` could return a 1-character ID instead of `''`.

## Changes

```diff
return (size = defaultSize) => {
+  if (!size) return ''
   let id = ''
   while (true) {
```

Add regression tests for zero-size behavior in `customAlphabet()` and `customRandom()`:

```diff
+equal(customAlphabet('abc')(0), '')
+equal(customAlphabet('abc', 0)(0), '')
+
+let nanoid0 = customRandom('abc', 5, size => new Uint8Array(size))
+equal(nanoid0(0), '')
```

Raise the `customAlphabet` size budget to match the new bundled size:

```diff
-"limit": "165 B"
+"limit": "173 B"
```

## Size Impact

`customAlphabet` grows by `8 B` in the bundled, minified, brotlied size check, from `165 B` to `173 B`.