### PR TITLE
Remove redundant browser step cast

### DIFF
--- a/index.browser.js
+++ b/index.browser.js
@@ -39,7 +39,7 @@ export let customRandom = (alphabet, defaultSize, getRandom) => {
     while (true) {
       let bytes = getRandom(step)
       // A compact alternative for `for (var i = 0; i < step; i++)`.
-      let j = step | 0
+      let j = step
       while (j--) {
         // Adding `|| ''` refuses a random byte that exceeds the alphabet size.
         id += alphabet[bytes[j] & mask] || ''


### PR DESCRIPTION
## What

Remove the redundant `| 0` cast from the browser `customRandom()` loop counter.

This keeps the browser implementation aligned with the Node version, which already uses `step` directly.

## Why

In the browser implementation, `step` is already an integer:

```js
let step = -~((1.6 * mask * defaultSize) / alphabet.length)
```

So this cast is redundant:

```js
let j = step | 0
```

Removing it does not change behavior with the current code, but it does make the browser bundle slightly smaller.

## Changes

```diff
- let j = step | 0
+ let j = step
```

Apply this change in:

- `index.browser.js`

## Size Impact

`customAlphabet` gets `2 B` smaller in the bundled, minified, brotlied size check:

- before: `173 B`
- after: `171 B`

No size budget update is applied.