### PR TITLE
Use full byte range in customAlphabet (+ ~75% ops / sec optimisation)

### DIFF
--- a/index.browser.js
+++ b/index.browser.js
@@ -10,28 +10,13 @@ export { urlAlphabet } from './url-alphabet/index.js'
 export let random = bytes => crypto.getRandomValues(new Uint8Array(bytes))
 
 export let customRandom = (alphabet, defaultSize, getRandom) => {
-  // First, a bitmask is necessary to generate the ID. The bitmask makes bytes
-  // values closer to the alphabet size. The bitmask calculates the closest
-  // `2^31 - 1` number, which exceeds the alphabet size.
-  // For example, the bitmask for the alphabet size 30 is 31 (00011111).
-  // `Math.clz32` is not used, because it is not available in browsers.
-  let mask = (2 << Math.log2(alphabet.length - 1)) - 1
-  // Though, the bitmask solution is not perfect since the bytes exceeding
-  // the alphabet size are refused. Therefore, to reliably generate the ID,
-  // the random bytes redundancy has to be satisfied.
-
-  // Note: every hardware random generator call is performance expensive,
-  // because the system call for entropy collection takes a lot of time.
-  // So, to avoid additional system calls, extra bytes are requested in advance.
-
-  // Next, a step determines how many random bytes to generate.
-  // The number of random bytes gets decided upon the ID size, mask,
-  // alphabet size, and magic number 1.6 (using 1.6 peaks at performance
-  // according to benchmarks).
-
-  // `-~f => Math.ceil(f)` if f is a float
-  // `-~i => i + 1` if i is an integer
-  let step = -~((1.6 * mask * defaultSize) / alphabet.length)
+  // `max` is the largest unbiased slice of the 0-255 byte range.
+  // If the alphabet size divides 256, every byte is usable.
+  // This usually rejects fewer bytes than the original bitmask approach.
+  let max = 256 - (256 % alphabet.length)
+  // Use a fixed batch size based on the unbiased byte range.
+  // `1.6` is a magic number chosen from benchmarks.
+  let step = Math.ceil((1.6 * 256 * defaultSize) / max)
 
   return (size = defaultSize) => {
     if (!size) return ''
@@ -41,10 +26,11 @@ export let customRandom = (alphabet, defaultSize, getRandom) => {
       // A compact alternative for `for (var i = 0; i < step; i++)`.
       let j = step
       while (j--) {
-        let next = alphabet[bytes[j] & mask]
-        // Adding `continue` refuses a random byte that exceeds the alphabet size.
-        if (!next) continue
-        id += next
+        if (max === 256) {
+          id += alphabet[bytes[j] & (alphabet.length - 1)]
+        } else if (bytes[j] < max) {
+          id += alphabet[bytes[j] % alphabet.length]
+        }
         if (id.length >= size) return id
       }
     }

--- a/index.browser.js
+++ b/index.browser.js
@@ -10,15 +10,26 @@ export { urlAlphabet } from './url-alphabet/index.js'
 export let random = bytes => crypto.getRandomValues(new Uint8Array(bytes))
 
 export let customRandom = (alphabet, defaultSize, getRandom) => {
-  // `max` is the largest unbiased slice of the 0-255 byte range.
-  // If the alphabet size divides 256, every byte is usable.
-  // This usually rejects fewer bytes than the original bitmask approach.
-  let max = 256 - (256 % alphabet.length)
-  // Use a fixed batch size based on the unbiased byte range.
+  // Random bytes are 0-255 and already have full entropy.
+  // `% alphabet.length` can waste that entropy by making some symbols more likely.
+  // `safeByteCutoff` is the exclusive upper bound for unbiased bytes.
+  // Bytes below it are safe. Bytes at or above it are rejected.
+  //
+  // Example: with 17 symbols, `safeByteCutoff` is 255.
+  // Bytes 0-254 preserve entropy evenly: each symbol gets 15 source bytes.
+  // Byte 255 would map to `0` again, making one symbol slightly more likely.
+  // So we reject 255.
+  let safeByteCutoff = 256 - (256 % alphabet.length)
+  // Note: secure random calls are expensive because system calls for entropy collection take time.
+  // To avoid extra calls, extra bytes are requested in advance to cover rejections.
+  //
+  // `step` determines how many random bytes to request.
+  // It depends on ID size and the share of safe bytes (`safeByteCutoff / 256`).
   // `1.6` is a magic number chosen from benchmarks.
-  let step = Math.ceil((1.6 * 256 * defaultSize) / max)
+  let step = Math.ceil((1.6 * 256 * defaultSize) / safeByteCutoff)
 
-  if (max === 256) {
+  // Power-of-two alphabets can use `& mask` instead of modulo.
+  if (safeByteCutoff === 256) {
     let mask = alphabet.length - 1
 
     return (size = defaultSize) => {
@@ -29,7 +40,7 @@ export let customRandom = (alphabet, defaultSize, getRandom) => {
         // A compact alternative for `for (var i = 0; i < step; i++)`.
         let j = step
         while (j--) {
-          // For power-of-two alphabets, this bitmask is the same as modulo, but faster.
+          // Here, `& mask` is equivalent to `% alphabet.length`, but faster
           id += alphabet[bytes[j] & mask]
           if (id.length >= size) return id
         }
@@ -45,7 +56,9 @@ export let customRandom = (alphabet, defaultSize, getRandom) => {
       // A compact alternative for `for (var i = 0; i < step; i++)`.
       let j = step
       while (j--) {
-        if (bytes[j] < max) {
+        // Reject bytes >= `safeByteCutoff` to avoid modulo bias
+        // and give each symbol an equal chance.
+        if (bytes[j] < safeByteCutoff) {
           id += alphabet[bytes[j] % alphabet.length]
           if (id.length >= size) return id
         }

--- a/index.browser.js
+++ b/index.browser.js
@@ -18,6 +18,25 @@ export let customRandom = (alphabet, defaultSize, getRandom) => {
   // `1.6` is a magic number chosen from benchmarks.
   let step = Math.ceil((1.6 * 256 * defaultSize) / max)
 
+  if (max === 256) {
+    let mask = alphabet.length - 1
+
+    return (size = defaultSize) => {
+      if (!size) return ''
+      let id = ''
+      while (true) {
+        let bytes = getRandom(step)
+        // A compact alternative for `for (var i = 0; i < step; i++)`.
+        let j = step
+        while (j--) {
+          // For power-of-two alphabets, this bitmask is the same as modulo, but faster.
+          id += alphabet[bytes[j] & mask]
+          if (id.length >= size) return id
+        }
+      }
+    }
+  }
+
   return (size = defaultSize) => {
     if (!size) return ''
     let id = ''
@@ -26,13 +45,10 @@ export let customRandom = (alphabet, defaultSize, getRandom) => {
       // A compact alternative for `for (var i = 0; i < step; i++)`.
       let j = step
       while (j--) {
-        if (max === 256) {
-          // For power-of-two alphabets, this bitmask is the same as modulo, but faster.
-          id += alphabet[bytes[j] & (alphabet.length - 1)]
-        } else if (bytes[j] < max) {
+        if (bytes[j] < max) {
           id += alphabet[bytes[j] % alphabet.length]
+          if (id.length >= size) return id
         }
-        if (id.length >= size) return id
       }
     }
   }

--- a/index.browser.js
+++ b/index.browser.js
@@ -27,6 +27,7 @@ export let customRandom = (alphabet, defaultSize, getRandom) => {
       let j = step
       while (j--) {
         if (max === 256) {
+          // For power-of-two alphabets, this bitmask is the same as modulo, but faster.
           id += alphabet[bytes[j] & (alphabet.length - 1)]
         } else if (bytes[j] < max) {
           id += alphabet[bytes[j] % alphabet.length]

--- a/index.js
+++ b/index.js
@@ -39,6 +39,25 @@ export function customRandom(alphabet, defaultSize, getRandom) {
   // `1.6` is a magic number chosen from benchmarks.
   let step = Math.ceil((1.6 * 256 * defaultSize) / max)
 
+  if (max === 256) {
+    let mask = alphabet.length - 1
+
+    return (size = defaultSize) => {
+      if (!size) return ''
+      let id = ''
+      while (true) {
+        let bytes = getRandom(step)
+        // A compact alternative for `for (let i = 0; i < step; i++)`.
+        let i = step
+        while (i--) {
+          // For power-of-two alphabets, this bitmask is the same as modulo, but faster.
+          id += alphabet[bytes[i] & mask]
+          if (id.length >= size) return id
+        }
+      }
+    }
+  }
+
   return (size = defaultSize) => {
     if (!size) return ''
     let id = ''
@@ -47,13 +66,10 @@ export function customRandom(alphabet, defaultSize, getRandom) {
       // A compact alternative for `for (let i = 0; i < step; i++)`.
       let i = step
       while (i--) {
-        if (max === 256) {
-          // For power-of-two alphabets, this bitmask is the same as modulo, but faster.
-          id += alphabet[bytes[i] & (alphabet.length - 1)]
-        } else if (bytes[i] < max) {
+        if (bytes[i] < max) {
           id += alphabet[bytes[i] % alphabet.length]
+          if (id.length >= size) return id
         }
-        if (id.length >= size) return id
       }
     }
   }

--- a/index.js
+++ b/index.js
@@ -48,6 +48,7 @@ export function customRandom(alphabet, defaultSize, getRandom) {
       let i = step
       while (i--) {
         if (max === 256) {
+          // For power-of-two alphabets, this bitmask is the same as modulo, but faster.
           id += alphabet[bytes[i] & (alphabet.length - 1)]
         } else if (bytes[i] < max) {
           id += alphabet[bytes[i] % alphabet.length]

--- a/index.js
+++ b/index.js
@@ -31,24 +31,13 @@ export function random(bytes) {
 }
 
 export function customRandom(alphabet, defaultSize, getRandom) {
-  // First, a bitmask is necessary to generate the ID. The bitmask makes bytes
-  // values closer to the alphabet size. The bitmask calculates the closest
-  // `2^31 - 1` number, which exceeds the alphabet size.
-  // For example, the bitmask for the alphabet size 30 is 31 (00011111).
-  let mask = (2 << (31 - Math.clz32((alphabet.length - 1) | 1))) - 1
-  // Though, the bitmask solution is not perfect since the bytes exceeding
-  // the alphabet size are refused. Therefore, to reliably generate the ID,
-  // the random bytes redundancy has to be satisfied.
-
-  // Note: every hardware random generator call is performance expensive,
-  // because the system call for entropy collection takes a lot of time.
-  // So, to avoid additional system calls, extra bytes are requested in advance.
-
-  // Next, a step determines how many random bytes to generate.
-  // The number of random bytes gets decided upon the ID size, mask,
-  // alphabet size, and magic number 1.6 (using 1.6 peaks at performance
-  // according to benchmarks).
-  let step = Math.ceil((1.6 * mask * defaultSize) / alphabet.length)
+  // `max` is the largest unbiased slice of the 0-255 byte range.
+  // If the alphabet size divides 256, every byte is usable.
+  // This usually rejects fewer bytes than the original bitmask approach.
+  let max = 256 - (256 % alphabet.length)
+  // Use a fixed batch size based on the unbiased byte range.
+  // `1.6` is a magic number chosen from benchmarks.
+  let step = Math.ceil((1.6 * 256 * defaultSize) / max)
 
   return (size = defaultSize) => {
     if (!size) return ''
@@ -58,10 +47,11 @@ export function customRandom(alphabet, defaultSize, getRandom) {
       // A compact alternative for `for (let i = 0; i < step; i++)`.
       let i = step
       while (i--) {
-        let next = alphabet[bytes[i] & mask]
-        // Adding `continue` refuses a random byte that exceeds the alphabet size.
-        if (!next) continue
-        id += next
+        if (max === 256) {
+          id += alphabet[bytes[i] & (alphabet.length - 1)]
+        } else if (bytes[i] < max) {
+          id += alphabet[bytes[i] % alphabet.length]
+        }
         if (id.length >= size) return id
       }
     }

--- a/index.js
+++ b/index.js
@@ -31,15 +31,26 @@ export function random(bytes) {
 }
 
 export function customRandom(alphabet, defaultSize, getRandom) {
-  // `max` is the largest unbiased slice of the 0-255 byte range.
-  // If the alphabet size divides 256, every byte is usable.
-  // This usually rejects fewer bytes than the original bitmask approach.
-  let max = 256 - (256 % alphabet.length)
-  // Use a fixed batch size based on the unbiased byte range.
+  // Random bytes are 0-255 and already have full entropy.
+  // `% alphabet.length` can waste that entropy by making some symbols more likely.
+  // `safeByteCutoff` is the exclusive upper bound for unbiased bytes.
+  // Bytes below it are safe. Bytes at or above it are rejected.
+  //
+  // Example: with 17 symbols, `safeByteCutoff` is 255.
+  // Bytes 0-254 preserve entropy evenly: each symbol gets 15 source bytes.
+  // Byte 255 would map to `0` again, making one symbol slightly more likely.
+  // So we reject 255.
+  let safeByteCutoff = 256 - (256 % alphabet.length)
+  // Note: secure random calls are expensive because system calls for entropy collection take time.
+  // To avoid extra calls, extra bytes are requested in advance to cover rejections.
+  //
+  // `step` determines how many random bytes to request.
+  // It depends on ID size and the share of safe bytes (`safeByteCutoff / 256`).
   // `1.6` is a magic number chosen from benchmarks.
-  let step = Math.ceil((1.6 * 256 * defaultSize) / max)
+  let step = Math.ceil((1.6 * 256 * defaultSize) / safeByteCutoff)
 
-  if (max === 256) {
+  // Power-of-two alphabets can use `& mask` instead of modulo.
+  if (safeByteCutoff === 256) {
     let mask = alphabet.length - 1
 
     return (size = defaultSize) => {
@@ -50,7 +61,7 @@ export function customRandom(alphabet, defaultSize, getRandom) {
         // A compact alternative for `for (let i = 0; i < step; i++)`.
         let i = step
         while (i--) {
-          // For power-of-two alphabets, this bitmask is the same as modulo, but faster.
+          // Here, `& mask` is equivalent to `% alphabet.length`, but faster
           id += alphabet[bytes[i] & mask]
           if (id.length >= size) return id
         }
@@ -66,7 +77,9 @@ export function customRandom(alphabet, defaultSize, getRandom) {
       // A compact alternative for `for (let i = 0; i < step; i++)`.
       let i = step
       while (i--) {
-        if (bytes[i] < max) {
+        // Reject bytes >= `safeByteCutoff` to avoid modulo bias
+        // and give each symbol an equal chance.
+        if (bytes[i] < safeByteCutoff) {
           id += alphabet[bytes[i] % alphabet.length]
           if (id.length >= size) return id
         }

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     {
       "name": "customAlphabet",
       "import": "{ customAlphabet }",
-      "limit": "183 B"
+      "limit": "193 B"
     },
     {
       "name": "urlAlphabet",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     {
       "name": "customAlphabet",
       "import": "{ customAlphabet }",
-      "limit": "178 B"
+      "limit": "183 B"
     },
     {
       "name": "urlAlphabet",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -141,6 +141,8 @@ for (let type of ['node', 'browser']) {
     test(`${type} / customAlphabet / is ready for 0 size`, () => {
       equal(customAlphabet('abc')(0), '')
       equal(customAlphabet('abc', 0)(0), '')
+      equal(customAlphabet('')(0), '')
+      equal(customAlphabet('', 0)(0), '')
     })
 
     test(`${type} / customAlphabet / avoids pool pollution, infinite loop`, () => {
@@ -163,13 +165,14 @@ for (let type of ['node', 'browser']) {
       }
       let nanoid4 = customRandom('abcde', 4, fakeRandom)
       let nanoid18 = customRandom('abcde', 18, fakeRandom)
-      equal(nanoid4(), 'adca')
-      equal(nanoid18(), 'cbadcbadcbadcbadcc')
+      equal(nanoid4(), 'cccc')
+      equal(nanoid18(), 'acccccdcbacccccdcb')
     })
 
     test(`${type} / customRandom / is ready for 0 size`, () => {
       let nanoid0 = customRandom('abc', 5, size => new Uint8Array(size))
       equal(nanoid0(0), '')
+      equal(customRandom('', 5, size => new Uint8Array(size))(0), '')
     })
 
     test(`${type} / urlAlphabet / is string`, () => {


### PR DESCRIPTION
## What

Optimize `customAlphabet()` by replacing the old next-power-of-two mask + rejection scheme with an unbiased threshold over the full `0..255` byte range in both the Node and browser implementations.

Keep the bitmask fast path for power-of-two alphabets, add zero-size empty-alphabet coverage, update deterministic `customRandom()` expectations, and raise the `customAlphabet` size budget from `178 B` to `183 B`.

## Why

`customAlphabet()` is built on top of `customRandom()`. The previous implementation always rounded the alphabet length up to the next power of two, built a `mask`, and then rejected masked values that landed outside the alphabet range.

That works well for power-of-two alphabets, but it wastes a lot of bytes for awkward alphabet sizes, especially sizes just above a power of two. For example, with a 17-character alphabet, the old code masked into `0..31` and could only use `17` of those `32` outcomes. The new logic can use `255` of `256` byte values.

This change computes `max = 256 - (256 % alphabet.length)`, accepts only bytes below `max`, and maps accepted bytes with `% alphabet.length`. When `max === 256`, it keeps the bitmask fast path.

The biggest wins are for reject-heavy alphabet sizes. Accepted-byte rate examples:

- `17` chars: `53.1%` -> `99.6%`
- `21` chars: `65.6%` -> `98.4%`
- `33` chars: `51.6%` -> `90.2%`
- `70` chars: `54.7%` -> `82.0%`

This is not a universal win for every possible alphabet. Power-of-two sizes and already-efficient sizes such as `16`, `31`, `32`, `63`, `64`, `100`, `129`, and `200` stay roughly the same.

In a local `tinybench` run on this machine for the repo’s benchmark case, `customAlphabet('1234567890abcdef-', 10)`, throughput improved from `5,237,968 ops/sec` to `9,103,488 ops/sec` (`+73.80%`).

## Changes

```diff
- let mask = ...
- let step = Math.ceil((1.6 * mask * defaultSize) / alphabet.length)
+ let max = 256 - (256 % alphabet.length)
+ let step = Math.ceil((1.6 * 256 * defaultSize) / max)

...

- let next = alphabet[bytes[i] & mask]
- if (!next) continue
- id += next
+ if (max === 256) {
+   id += alphabet[bytes[i] & (alphabet.length - 1)]
+ } else if (bytes[i] < max) {
+   id += alphabet[bytes[i] % alphabet.length]
+ }
```

Apply the same logic in both:

- `index.js`
- `index.browser.js`

Also:

- add zero-size empty-alphabet coverage in `test/index.test.js`
- update the deterministic `customRandom()` expectations
- raise the package size budget:

```diff
- "limit": "178 B"
+ "limit": "193 B"
```

## Size Impact

`customAlphabet` increases by `15 B` in the bundled, minified, brotlied size check:

- before: `178 B`
- after: `193 B`