### PR TITLE
Exclude local config from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,6 +2,9 @@ test/
 tsconfig.json
 coverage/
 
+.claude/
+CLAUDE.md
+
 img/
 
 jsr.json


### PR DESCRIPTION
## Summary

- Exclude maintainer-local configuration files from the npm package
- Keep the current package ignore approach and avoid changing runtime exports

## Verification

- Added temporary local config files and ran `npm pack --dry-run --json`; confirmed none were included in the packed file list
- Ran `npm pack --dry-run --json` again after removing the temporary files
- Ran `git diff --check`

Fixes #590