### PR TITLE
Add .claude/ to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,3 +7,4 @@ img/
 jsr.json
 SECURITY.md
 pnpm-workspace.yaml
+.claude/


### PR DESCRIPTION
## Summary

Adds `.claude/` to `.npmignore` to prevent shipping Claude Code configuration files in the published npm tarball.

## Changes

- `.npmignore`: Added `.claude/` entry

## Why

The published tarball currently includes `.claude/settings.local.json`, which contains maintainer-local workflow paths. This adds unnecessary bytes, exposes maintainer dev paths, and could be auto-loaded by downstream Claude Code sessions.

Closes #590