### PR TITLE
fix: add files allowlist to prevent publishing unnecessary files

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,5 +114,17 @@
   "clean-publish": {
     "cleanDocs": true,
     "cleanComments": true
-  }
+  },
+  "files": [
+    "index.js",
+    "index.browser.js",
+    "index.d.ts",
+    "nanoid.js",
+    "non-secure/",
+    "url-alphabet/",
+    "bin/",
+    "LICENSE",
+    "README.md",
+    "CHANGELOG.md"
+  ]
 }


### PR DESCRIPTION
## Problem

The published npm tarball currently includes .claude/settings.local.json and other dev-only files because package.json has no files field.

This was reported in #590 where the author found .claude/settings.local.json inside the published tarball.

## Fix

Add an explicit files allowlist to package.json that only includes runtime-needed files:

- index.js, index.browser.js, index.d.ts, nanoid.js (main modules)
- non-secure/, url-alphabet/, bin/ (submodules and CLI)
- LICENSE, README.md, CHANGELOG.md (docs)

This is more reliable than the existing .npmignore denylist approach.

Fixes #590