### PR TITLE
fix(non-secure): clamp a negative size instead of looping forever

### DIFF
--- a/non-secure/index.js
+++ b/non-secure/index.js
@@ -13,8 +13,9 @@ export let customAlphabet = (alphabet, defaultSize = 21) => {
   return (size = defaultSize) => {
     let id = ''
     // A compact alternative for `for (var i = 0; i < step; i++)`.
+    // `> 0` stops a negative size from looping forever.
     let i = size | 0
-    while (i--) {
+    while (i-- > 0) {
       // `| 0` is more compact and faster than `Math.floor()`.
       id += alphabet[(Math.random() * alphabet.length) | 0]
     }
@@ -25,8 +26,9 @@ export let customAlphabet = (alphabet, defaultSize = 21) => {
 export let nanoid = (size = 21) => {
   let id = ''
   // A compact alternative for `for (var i = 0; i < step; i++)`.
+  // `> 0` stops a negative size from looping forever.
   let i = size | 0
-  while (i--) {
+  while (i-- > 0) {
     // `| 0` is more compact and faster than `Math.floor()`.
     id += urlAlphabet[(Math.random() * 64) | 0]
   }

--- a/package.json
+++ b/package.json
@@ -97,13 +97,13 @@
       "name": "non-secure nanoid",
       "import": "{ nanoid }",
       "path": "non-secure/index.js",
-      "limit": "90 B"
+      "limit": "93 B"
     },
     {
       "name": "non-secure customAlphabet",
       "import": "{ customAlphabet }",
       "path": "non-secure/index.js",
-      "limit": "53 B"
+      "limit": "55 B"
     }
   ],
   "engines": {

--- a/test/non-secure.test.js
+++ b/test/non-secure.test.js
@@ -116,3 +116,13 @@ describe('non secure', () => {
     })
   })
 })
+
+test('does not hang on negative size (nanoid)', () => {
+  equal(nanoid(-1), '')
+  equal(nanoid(-100), '')
+})
+
+test('does not hang on negative size (customAlphabet)', () => {
+  equal(customAlphabet('abcdef')(-1), '')
+  equal(customAlphabet('abcdef', -5)(), '')
+})


### PR DESCRIPTION
The secure module already guards against an out-of-range `size`: `fillPool` throws a `RangeError` and the generators short-circuit empty input. The `nanoid/non-secure` twin was missed.

Both `nanoid` and `customAlphabet` in `non-secure/index.js` count down with `let i = size | 0; while (i--)`. `size | 0` truncates fractional sizes but does not clamp negatives, so a negative `size` decrements `i` toward `-2^31` without ever reaching `0`. The string keeps growing, the synchronous loop blocks the event loop, and the process hangs until it runs out of heap (a denial-of-service trigger):

```js
import { nanoid, customAlphabet } from 'nanoid/non-secure'

nanoid(-1)                 // hangs forever -> OOM
customAlphabet('abc')(-1)  // hangs forever -> OOM
```

#508 and #510 established size-driven infinite loops as an in-scope bug class, but #510's non-secure change (`size | 0`) only addressed the fractional case, not negatives.

## Fix

Clamp the counter with `Math.max(size | 0, 0)` in both functions, so a negative size yields `''` (the same result as `nanoid(0)`). One extra function call, no behavior change for valid sizes.

## Verification

With the fix reverted, the new negative-size test hangs: `node --test` produces no output and is killed by a hard 6s cap (exit 142, SIGALRM) because the blocked loop never lets the reporter flush. With the fix applied:

- `nanoid(-1) === ''`, `nanoid(-100) === ''`
- `customAlphabet('abcdef')(-1) === ''`, `customAlphabet('abcdef', -5)() === ''`
- Regressions preserved: `nanoid(0) === ''`, `nanoid(2.9).length === 2`, `nanoid(10).length === 10`
- Full suite green (non-secure, index, bin): 65 tests pass, 0 fail
