### PR TITLE
fix(non-secure): clamp negative size to prevent infinite loop

### DIFF
--- a/non-secure/index.cjs
+++ b/non-secure/index.cjs
@@ -11,8 +11,9 @@ let customAlphabet = (alphabet, defaultSize = 21) => {
   return (size = defaultSize) => {
     let id = ''
     // A compact alternative for `for (var i = 0; i < step; i++)`.
+    // `> 0` stops a negative size from looping forever.
     let i = size | 0
-    while (i--) {
+    while (i-- > 0) {
       // `| 0` is more compact and faster than `Math.floor()`.
       id += alphabet[(Math.random() * alphabet.length) | 0]
     }
@@ -23,8 +24,9 @@ let customAlphabet = (alphabet, defaultSize = 21) => {
 let nanoid = (size = 21) => {
   let id = ''
   // A compact alternative for `for (var i = 0; i < step; i++)`.
+  // `> 0` stops a negative size from looping forever.
   let i = size | 0
-  while (i--) {
+  while (i-- > 0) {
     // `| 0` is more compact and faster than `Math.floor()`.
     id += urlAlphabet[(Math.random() * 64) | 0]
   }

--- a/non-secure/index.js
+++ b/non-secure/index.js
@@ -11,8 +11,9 @@ let customAlphabet = (alphabet, defaultSize = 21) => {
   return (size = defaultSize) => {
     let id = ''
     // A compact alternative for `for (var i = 0; i < step; i++)`.
+    // `> 0` stops a negative size from looping forever.
     let i = size | 0
-    while (i--) {
+    while (i-- > 0) {
       // `| 0` is more compact and faster than `Math.floor()`.
       id += alphabet[(Math.random() * alphabet.length) | 0]
     }
@@ -23,8 +24,9 @@ let customAlphabet = (alphabet, defaultSize = 21) => {
 let nanoid = (size = 21) => {
   let id = ''
   // A compact alternative for `for (var i = 0; i < step; i++)`.
+  // `> 0` stops a negative size from looping forever.
   let i = size | 0
-  while (i--) {
+  while (i-- > 0) {
     // `| 0` is more compact and faster than `Math.floor()`.
     id += urlAlphabet[(Math.random() * 64) | 0]
   }

--- a/test/non-secure.test.cjs
+++ b/test/non-secure.test.cjs
@@ -104,4 +104,14 @@ test('customAlphabet / avoids pool pollution, infinite loop', () => {
   not.equal(second, third)
 })
 
+test('nanoid / does not hang on negative size', () => {
+  is(nanoid(-1), '')
+  is(nanoid(-100), '')
+})
+
+test('customAlphabet / does not hang on negative size', () => {
+  is(customAlphabet('abcdef')(-1), '')
+  is(customAlphabet('abcdef', -5)(), '')
+})
+
 test.run()


### PR DESCRIPTION
On the `v3` branch the non-secure `nanoid` and `customAlphabet` still use `while (i--)`, which never terminates for a negative `size`. `nanoid(-1)` keeps appending to the string and grows until the process runs out of memory.

This was already fixed on main in #600 (released in 5.1.16) by changing the guard to `while (i-- > 0)`, but the `v3` branch (latest 3.3.15) didn't get it.

This backports the same guard to both `non-secure/index.js` and `non-secure/index.cjs`, and adds the negative-size tests from #600 in v3's uvu style.

For non-negative sizes the loop runs the exact same number of iterations as before, so there is no behavior change for normal input.

Test plan: `npx uvu . "non-secure.test.cjs$"` passes 11/11. Without the guard the two new negative-size tests hang the runner; with it `nanoid(-1)` and `customAlphabet('abcdef')(-1)` return an empty string.
