### PR TITLE
use `!alphabet` instead `!alphabet.length`

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ const POOL_MAX = GET_RANDOM_LIMIT / 2
 export function customAlphabet(alphabet, defaultSize = 21) {
   if (
     typeof alphabet !== 'string' ||
-    !alphabet.length ||
+    !alphabet ||
     alphabet.length > 256
   ) {
     return customRandom(alphabet, defaultSize, random)


### PR DESCRIPTION
reduce 7 chars, since same for an empty string `''` 