### PR TITLE
async/index.nativs.js customAlphabet still vulnerable

### DIFF
--- a/async/index.native.js
+++ b/async/index.native.js
@@ -36,7 +36,10 @@ let customAlphabet = (alphabet, defaultSize = 21) => {
       return tick(id, size)
     })
 
-  return size => tick('', size)
+  return (size = defaultSize) => {
+    if (size <= 0) return Promise.resolve('')
+    return tick('', size)
+  }
 }
 
 let nanoid = (size = 21) =>


### PR DESCRIPTION
Sonatype is still flagging Nanoid 3.3.17 on CVE-2026-67213 due to async/index.native.js not patching the <= 0 size input. Mirrored the fix in async/index.js.